### PR TITLE
Improve Cal AI flow, time parsing, editable drafts, and event UI

### DIFF
--- a/src/components/Calendar/DayView.jsx
+++ b/src/components/Calendar/DayView.jsx
@@ -2,7 +2,7 @@ import { motion } from 'framer-motion';
 import { getDayHours, getDayHoursWithHalf, formatTime, getEventPosition, isToday, getCurrentTimePosition, isBusinessHour } from '../../utils/dateUtils';
 import { useCalendar } from '../../contexts/CalendarContext';
 import { useEvents } from '../../contexts/EventsContext';
-import { cn } from '../../utils/helpers';
+import { cn, getEventColor } from '../../utils/helpers';
 import { Clock } from 'lucide-react';
 import './DayView.css';
 
@@ -133,7 +133,7 @@ const DayView = () => {
                   style={{
                     top: `${top}px`,
                     height: `${Math.max(height, 40)}px`,
-                    backgroundColor: event.color || '#6366f1'
+                    backgroundColor: event.color || getEventColor(event.category)
                   }}
                 >
                   <div className="event-content">

--- a/src/components/Calendar/MonthView.jsx
+++ b/src/components/Calendar/MonthView.jsx
@@ -1,27 +1,32 @@
 import { motion } from 'framer-motion';
-import { getMonthDays, isSameMonth, isToday, isSameDay } from '../../utils/dateUtils';
-import { useCalendar } from '../../contexts/CalendarContext';
+import { getMonthDays, isSameMonth, isToday } from '../../utils/dateUtils';
+import { useCalendar, CALENDAR_VIEWS } from '../../contexts/CalendarContext';
 import { useEvents } from '../../contexts/EventsContext';
-import { cn } from '../../utils/helpers';
+import { cn, getEventColor } from '../../utils/helpers';
 import './MonthView.css';
 
 const MonthView = () => {
-  const { currentDate, openEventModal } = useCalendar();
+  const { currentDate, openEventModal, setView, setCurrentDate } = useCalendar();
   const { getEventsForDate } = useEvents();
 
   const monthDays = getMonthDays(currentDate);
   const weekDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
 
   const handleDayClick = (day) => {
-    openEventModal({ 
-      start: new Date(day.getFullYear(), day.getMonth(), day.getDate(), 9, 0),
-      end: new Date(day.getFullYear(), day.getMonth(), day.getDate(), 10, 0)
-    });
+    setCurrentDate(day);
+    setView(CALENDAR_VIEWS.DAY);
   };
 
   const handleEventClick = (event, e) => {
     e.stopPropagation();
     openEventModal(event);
+  };
+
+  const handleDayDoubleClick = (day) => {
+    openEventModal({
+      start: new Date(day.getFullYear(), day.getMonth(), day.getDate(), 9, 0),
+      end: new Date(day.getFullYear(), day.getMonth(), day.getDate(), 10, 0)
+    });
   };
 
   return (
@@ -49,6 +54,7 @@ const MonthView = () => {
               animate={{ opacity: 1, scale: 1 }}
               transition={{ delay: index * 0.01 }}
               onClick={() => handleDayClick(day)}
+              onDoubleClick={() => handleDayDoubleClick(day)}
               className={cn(
                 'month-day',
                 'glass-card',
@@ -70,7 +76,7 @@ const MonthView = () => {
                     whileHover={{ scale: 1.02 }}
                     onClick={(e) => handleEventClick(event, e)}
                     className="day-event"
-                    style={{ backgroundColor: event.color || '#6366f1' }}
+                    style={{ backgroundColor: event.color || getEventColor(event.category) }}
                   >
                     <span className="event-title">
                       {event.title}

--- a/src/components/Calendar/WeekView.jsx
+++ b/src/components/Calendar/WeekView.jsx
@@ -3,7 +3,7 @@ import { motion } from 'framer-motion';
 import { getWeekDays, getDayHours, formatTime, isToday } from '../../utils/dateUtils';
 import { useCalendar } from '../../contexts/CalendarContext';
 import { useEvents } from '../../contexts/EventsContext';
-import { cn } from '../../utils/helpers';
+import { cn, getEventColor } from '../../utils/helpers';
 import './WeekView.css';
 
 const WeekView = () => {
@@ -123,7 +123,7 @@ const WeekView = () => {
                         key={event.id}
                         className="event-chip"
                         style={{
-                          backgroundColor: event.color || (event.category === 'work' ? '#6366f1' : '#10b981')
+                          backgroundColor: event.color || getEventColor(event.category)
                         }}
                         onClick={(e) => handleEventClick(event, e)}
                         layout // Animate layout changes

--- a/src/components/Events/EventModal.css
+++ b/src/components/Events/EventModal.css
@@ -95,6 +95,68 @@
   gap: 1rem;
 }
 
+.quick-duration {
+  background: rgba(255, 255, 255, 0.03);
+  border: 1px dashed rgba(148, 163, 184, 0.2);
+  padding: 0.75rem 1rem;
+  border-radius: 12px;
+}
+
+.duration-buttons {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.duration-btn {
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  background: rgba(15, 23, 42, 0.4);
+  color: #e2e8f0;
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.35rem 0.6rem;
+  border-radius: 10px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.duration-btn:hover {
+  border-color: rgba(99, 102, 241, 0.6);
+  color: #c7d2fe;
+  transform: translateY(-1px);
+}
+
+.category-pills {
+  margin-top: 0.75rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.category-pill {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.4);
+  color: #e2e8f0;
+  font-size: 0.75rem;
+  font-weight: 600;
+  padding: 0.35rem 0.6rem;
+  border-radius: 999px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.category-pill.active {
+  border-color: var(--pill-color);
+  color: var(--pill-color);
+  box-shadow: 0 0 0 1px rgba(255, 255, 255, 0.1);
+}
+
+.category-pill:hover {
+  border-color: rgba(99, 102, 241, 0.6);
+  color: #c7d2fe;
+  transform: translateY(-1px);
+}
+
 .textarea {
   resize: vertical;
   min-height: 80px;

--- a/src/components/Events/EventModal.jsx
+++ b/src/components/Events/EventModal.jsx
@@ -3,7 +3,6 @@ import { motion, AnimatePresence } from 'framer-motion';
 import { X, Save, Trash2, MapPin, Clock, Tag, Palette, Repeat, Bell } from 'lucide-react';
 import { useCalendar } from '../../contexts/CalendarContext';
 import { useEvents } from '../../contexts/EventsContext';
-import { formatDate, formatTime } from '../../utils/dateUtils';
 import { getEventColor } from '../../utils/helpers';
 import { validateEvent } from '../../utils/eventValidator';
 import { RECURRENCE_TYPES, formatRecurrenceText } from '../../utils/recurringEvents';
@@ -21,7 +20,7 @@ const EventModal = () => {
     end: '',
     location: '',
     category: 'personal',
-    color: '#6366f1',
+    color: getEventColor('personal'),
     reminder: null,
     recurring: { type: RECURRENCE_TYPES.NONE }
   });
@@ -57,12 +56,22 @@ const EventModal = () => {
           end: endTime.toISOString().slice(0, 16),
           location: '',
           category: 'personal',
-          color: '#6366f1'
+          color: getEventColor('personal')
         });
         setIsEditing(false);
       }
     }
   }, [selectedEvent]);
+
+  const handleDurationChange = (minutes) => {
+    if (!formData.start) return;
+    const start = new Date(formData.start);
+    const end = new Date(start.getTime() + minutes * 60 * 1000);
+    setFormData(prev => ({
+      ...prev,
+      end: end.toISOString().slice(0, 16)
+    }));
+  };
 
   const handleSubmit = (e) => {
     e.preventDefault();
@@ -116,17 +125,25 @@ const EventModal = () => {
   };
 
   const categories = [
-    { value: 'work', label: 'Work', color: '#3b82f6' },
-    { value: 'personal', label: 'Personal', color: '#10b981' },
-    { value: 'health', label: 'Health', color: '#f59e0b' },
-    { value: 'social', label: 'Social', color: '#8b5cf6' },
-    { value: 'travel', label: 'Travel', color: '#06b6d4' },
-    { value: 'other', label: 'Other', color: '#6b7280' }
+    { value: 'work', label: 'Work', color: getEventColor('work') },
+    { value: 'personal', label: 'Personal', color: getEventColor('personal') },
+    { value: 'fun', label: 'Fun', color: getEventColor('fun') },
+    { value: 'hobby', label: 'Hobby', color: getEventColor('hobby') },
+    { value: 'task', label: 'Task', color: getEventColor('task') },
+    { value: 'todo', label: 'To-Do', color: getEventColor('todo') },
+    { value: 'event', label: 'Event', color: getEventColor('event') },
+    { value: 'appointment', label: 'Appointment', color: getEventColor('appointment') }
   ];
 
   const colorOptions = [
-    '#6366f1', '#8b5cf6', '#ec4899', '#ef4444',
-    '#f59e0b', '#10b981', '#06b6d4', '#6b7280'
+    getEventColor('work'),
+    getEventColor('personal'),
+    getEventColor('fun'),
+    getEventColor('hobby'),
+    getEventColor('task'),
+    getEventColor('todo'),
+    getEventColor('event'),
+    getEventColor('appointment')
   ];
 
   if (!isEventModalOpen) return null;
@@ -215,6 +232,22 @@ const EventModal = () => {
               </div>
             </div>
 
+            <div className="form-group quick-duration">
+              <label>Quick Duration</label>
+              <div className="duration-buttons">
+                {[15, 30, 60, 120].map(minutes => (
+                  <button
+                    key={minutes}
+                    type="button"
+                    onClick={() => handleDurationChange(minutes)}
+                    className="duration-btn"
+                  >
+                    {minutes < 60 ? `${minutes}m` : `${minutes / 60}h`}
+                  </button>
+                ))}
+              </div>
+            </div>
+
             <div className="form-group">
               <label htmlFor="location">
                 <MapPin size={16} />
@@ -246,7 +279,7 @@ const EventModal = () => {
                   value={formData.category}
                   onChange={(e) => {
                     const category = e.target.value;
-                    const color = categories.find(c => c.value === category)?.color || '#6366f1';
+                    const color = categories.find(c => c.value === category)?.color || getEventColor('personal');
                     handleChange('category', category);
                     handleChange('color', color);
                   }}
@@ -258,6 +291,22 @@ const EventModal = () => {
                     </option>
                   ))}
                 </select>
+                <div className="category-pills">
+                  {categories.map(category => (
+                    <button
+                      key={category.value}
+                      type="button"
+                      className={`category-pill ${formData.category === category.value ? 'active' : ''}`}
+                      style={{ '--pill-color': category.color }}
+                      onClick={() => {
+                        handleChange('category', category.value);
+                        handleChange('color', category.color);
+                      }}
+                    >
+                      {category.label}
+                    </button>
+                  ))}
+                </div>
               </div>
 
               <div className="form-group">

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -600,6 +600,29 @@
   font-size: 0.85rem;
 }
 
+.upgrade-todo {
+  margin: 24px 0;
+  padding: 18px;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(99, 102, 241, 0.2);
+}
+
+.upgrade-todo h4 {
+  margin: 0 0 12px;
+  font-size: 1rem;
+  color: #e2e8f0;
+}
+
+.upgrade-todo ol {
+  margin: 0;
+  padding-left: 18px;
+  color: #cbd5f5;
+  font-size: 0.85rem;
+  display: grid;
+  gap: 6px;
+}
+
 /* Scrollbar */
 .tab-content-wrapper::-webkit-scrollbar {
   width: 6px;

--- a/src/components/Settings/Settings.jsx
+++ b/src/components/Settings/Settings.jsx
@@ -444,6 +444,21 @@ const Settings = ({ isOpen, onClose }) => {
                         <h3>CalAI</h3>
                         <p>Version 2.0.1 (Nitro)</p>
                       </div>
+                      <div className="upgrade-todo">
+                        <h4>Cal Upgrade TODO</h4>
+                        <ol>
+                          <li>Route quick add input straight into Cal chat.</li>
+                          <li>Correct explicit times so 1:45pm stays 1:45pm.</li>
+                          <li>Open day view when clicking a date in month view.</li>
+                          <li>Add AI draft editing before confirming events.</li>
+                          <li>Refresh the event modal for faster edits.</li>
+                          <li>Always-show trash controls in upcoming events.</li>
+                          <li>Ensure AI-created events always carry times.</li>
+                          <li>Expand category + color system to 8 tags.</li>
+                          <li>Add category filters for upcoming events.</li>
+                          <li>Enable quick edit actions from the upcoming list.</li>
+                        </ol>
+                      </div>
                       <div className="legal-links-alt">
                         <a href="/privacy.html" target="_blank" rel="noopener noreferrer">Privacy Policy</a>
                         <span>•</span>

--- a/src/components/Sidebar/UpcomingSidebar.css
+++ b/src/components/Sidebar/UpcomingSidebar.css
@@ -19,6 +19,36 @@
     margin-bottom: 24px;
 }
 
+.category-filters {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 6px;
+    margin-bottom: 18px;
+}
+
+.filter-chip {
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(15, 23, 42, 0.4);
+    color: #cbd5f5;
+    padding: 4px 10px;
+    font-size: 0.7rem;
+    font-weight: 600;
+    border-radius: 999px;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.filter-chip.active {
+    border-color: rgba(99, 102, 241, 0.6);
+    color: #c7d2fe;
+    background: rgba(99, 102, 241, 0.15);
+}
+
+.filter-chip:hover {
+    border-color: rgba(99, 102, 241, 0.4);
+    color: #e2e8f0;
+}
+
 .sidebar-header h3 {
     font-size: 1.25rem;
     font-weight: 700;
@@ -46,7 +76,7 @@
 .upcoming-event-item {
     display: flex;
     gap: 16px;
-    padding: 12px;
+    padding: 12px 52px 12px 12px;
     border-radius: 16px;
     background: rgba(255, 255, 255, 0.02);
     border: 1px solid rgba(255, 255, 255, 0.03);
@@ -144,20 +174,13 @@
 }
 
 /* Actions */
-.event-actions-hover {
+.event-actions {
     position: absolute;
-    right: 8px;
+    right: 10px;
     top: 50%;
-    transform: translateY(-50%) translateX(100%);
+    transform: translateY(-50%);
     display: flex;
     gap: 6px;
-    opacity: 0;
-    transition: all 0.2s cubic-bezier(0.4, 0, 0.2, 1);
-}
-
-.upcoming-event-item:hover .event-actions-hover {
-    transform: translateY(-50%) translateX(0);
-    opacity: 1;
 }
 
 .action-btn {
@@ -177,8 +200,18 @@
     color: #f43f5e;
 }
 
+.action-btn.edit {
+    background: rgba(99, 102, 241, 0.12);
+    color: #818cf8;
+}
+
 .action-btn.delete:hover {
     background: #f43f5e;
+    color: white;
+}
+
+.action-btn.edit:hover {
+    background: #6366f1;
     color: white;
 }
 

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -49,9 +49,12 @@ export const getEventColor = (category) => {
   const colors = {
     work: '#3b82f6',
     personal: '#10b981',
-    health: '#f59e0b',
-    social: '#8b5cf6',
-    travel: '#06b6d4',
+    fun: '#ec4899',
+    hobby: '#8b5cf6',
+    task: '#f59e0b',
+    todo: '#22c55e',
+    event: '#ef4444',
+    appointment: '#06b6d4',
     default: '#6b7280'
   };
   


### PR DESCRIPTION
### Motivation
- Make the quick-input act as input for the AI assistant (branded as “Cal”) and let AI-drafted events be reviewed/edited before creation.
- Fix AI time-parsing issues so explicitly-stated times (e.g. “1:45pm”) are preserved and events always get valid start/end times.
- Improve month/day navigation and make AI-created events easier to edit and color-code.

### Description
- Route quick-add input into the AI chat flow and rename the assistant to “Cal”; the header now dispatches a `calai-ping` event and the AI sidebar handles parsing/drafting (`src/components/Header/Header.jsx`, `src/components/AI/AIChat.jsx`).
- Add editable AI draft flow: AI drafts are shown in the chat with actions to `Add`, `Edit` (opens the event modal), or `Discard` before the event is persisted (`AIChat` + event modal integration).
- Normalize parsed event times in `geminiService.parseEventFromText` via a new `normalizeParsedEvent` routine that extracts explicit time tokens and adjusts start/end accordingly, and provides sensible fallback durations when end times are missing (`src/services/geminiService.js`).
- Month/day UX: clicking a date in month view now opens the Day view and double-clicking opens the create-event modal pre-filled for that date (`MonthView` changes). Day/Week/Month views now use category colors via `getEventColor` consistently.
- Event modal refreshed with quick-duration buttons, category pills, expanded categories (8 tags) and color options for faster editing and creation (`EventModal.jsx`, `EventModal.css`, `src/utils/helpers.js`).
- Upcoming sidebar improved with always-visible edit/trash actions, category filters, and category-based color badges (`UpcomingSidebar.jsx`, `UpcomingSidebar.css`).
- Misc: updated UI copy and the Settings > About tab now lists the 10-item upgrade TODO to document the feature scope (`Settings.jsx`, `Settings.css`).

### Testing
- Started the development server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported the app ready (local + network URLs), which succeeded.
- Ran a browser smoke script (Playwright) that opened the app, clicked the AI button, and captured a screenshot (`artifacts/cal-updates.png`), which completed successfully.
- No unit tests were added or run as part of this change; the two manual/automated dev-run smoke checks above passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69680a03c6a8832e80cb18046fe9ad9a)