### PR TITLE
Add year view, 24h time, clock picker and refresh calendar UI/theme

### DIFF
--- a/src/components/AI/AIChat.jsx
+++ b/src/components/AI/AIChat.jsx
@@ -254,7 +254,7 @@ const AIChat = ({ isOpen, onClose }) => {
               type="text"
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
-              placeholder="Type or paste event details..."
+              placeholder="Chat with Cal"
               className="chat-input-field"
               autoFocus
             />

--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -3,6 +3,7 @@ import { useCalendar, CALENDAR_VIEWS } from '../../contexts/CalendarContext';
 import DayView from './DayView';
 import WeekView from './WeekView';
 import MonthView from './MonthView';
+import YearView from './YearView';
 import './Calendar.css';
 
 const Calendar = () => {
@@ -16,6 +17,8 @@ const Calendar = () => {
         return <WeekView key="week" />;
       case CALENDAR_VIEWS.MONTH:
         return <MonthView key="month" />;
+      case CALENDAR_VIEWS.YEAR:
+        return <YearView key="year" />;
       default:
         return <MonthView key="month" />;
     }

--- a/src/components/Calendar/DayView.css
+++ b/src/components/Calendar/DayView.css
@@ -211,6 +211,20 @@
   box-shadow: 0 2px 8px rgba(239, 68, 68, 0.3);
 }
 
+.current-time-label {
+  position: absolute;
+  left: 0.75rem;
+  top: -12px;
+  padding: 2px 8px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #fde68a;
+  border: 1px solid rgba(251, 191, 36, 0.45);
+  font-size: 0.7rem;
+  font-weight: 700;
+  border-radius: 8px;
+  letter-spacing: 0.04em;
+}
+
 .events-layer {
   position: absolute;
   top: 0;

--- a/src/components/Calendar/DayView.jsx
+++ b/src/components/Calendar/DayView.jsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { getDayHours, getDayHoursWithHalf, formatTime, getEventPosition, isToday, getCurrentTimePosition, isBusinessHour } from '../../utils/dateUtils';
+import { getDayHours, getDayHoursWithHalf, formatTime24, getEventPosition, isToday, getCurrentTimePosition, isBusinessHour } from '../../utils/dateUtils';
 import { useCalendar } from '../../contexts/CalendarContext';
 import { useEvents } from '../../contexts/EventsContext';
 import { cn, getEventColor } from '../../utils/helpers';
@@ -79,7 +79,7 @@ const DayView = () => {
             >
               {!slot.isHalfHour && (
                 <span className="time-label">
-                  {formatTime(slot.time)}
+                  {formatTime24(slot.time)}
                 </span>
               )}
               {slot.isHalfHour && (
@@ -112,6 +112,9 @@ const DayView = () => {
               <div className="current-time-line"></div>
               <div className="current-time-dot">
                 <Clock size={12} />
+              </div>
+              <div className="current-time-label">
+                {formatTime24(new Date())}
               </div>
             </div>
           )}
@@ -149,7 +152,7 @@ const DayView = () => {
                       </div>
                     )}
                     <div className="event-time">
-                      {formatTime(new Date(event.start))} - {formatTime(new Date(event.end))}
+                      {formatTime24(new Date(event.start))} - {formatTime24(new Date(event.end))}
                     </div>
                   </div>
                 </motion.div>

--- a/src/components/Calendar/MonthView.css
+++ b/src/components/Calendar/MonthView.css
@@ -3,6 +3,24 @@
   height: 100%;
 }
 
+.month-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.month-summary-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.month-summary-stat {
+  text-align: center;
+}
+
 .month-header {
   display: grid;
   grid-template-columns: repeat(7, 1fr);
@@ -30,8 +48,8 @@
 }
 
 .month-day {
-  min-height: 85px;
-  padding: 0.5rem;
+  min-height: 110px;
+  padding: 0.6rem;
   cursor: pointer;
   transition: all 0.2s ease;
   display: flex;
@@ -74,9 +92,9 @@
 }
 
 .day-number {
-  font-size: 0.875rem;
-  font-weight: 500;
-  margin-bottom: 0.5rem;
+  font-size: 0.9rem;
+  font-weight: 600;
+  margin-bottom: 0.35rem;
   color: var(--text-primary);
 }
 
@@ -84,23 +102,26 @@
   flex: 1;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 4px;
   overflow: hidden;
 }
 
 .day-event {
-  padding: 2px 6px;
-  border-radius: 4px;
-  font-size: 0.75rem;
-  font-weight: 500;
+  padding: 6px 8px;
+  border-radius: 8px;
+  font-size: 0.78rem;
+  font-weight: 600;
   color: white;
   cursor: pointer;
   transition: all 0.2s ease;
-  white-space: nowrap;
+  white-space: normal;
   overflow: hidden;
   text-overflow: ellipsis;
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
 }
 
 .day-event:hover {
@@ -112,6 +133,17 @@
   display: block;
   overflow: hidden;
   text-overflow: ellipsis;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.event-time {
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  opacity: 0.9;
 }
 
 .more-events {

--- a/src/components/Calendar/MonthView.jsx
+++ b/src/components/Calendar/MonthView.jsx
@@ -1,5 +1,5 @@
 import { motion } from 'framer-motion';
-import { getMonthDays, isSameMonth, isToday } from '../../utils/dateUtils';
+import { getMonthDays, isSameMonth, isToday, formatTime24 } from '../../utils/dateUtils';
 import { useCalendar, CALENDAR_VIEWS } from '../../contexts/CalendarContext';
 import { useEvents } from '../../contexts/EventsContext';
 import { cn, getEventColor } from '../../utils/helpers';
@@ -11,6 +11,9 @@ const MonthView = () => {
 
   const monthDays = getMonthDays(currentDate);
   const weekDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
+  const monthEventsCount = monthDays.reduce((total, day) => {
+    return isSameMonth(day, currentDate) ? total + getEventsForDate(day).length : total;
+  }, 0);
 
   const handleDayClick = (day) => {
     setCurrentDate(day);
@@ -31,6 +34,14 @@ const MonthView = () => {
 
   return (
     <div className="month-view">
+      <div className="month-summary glass-card">
+        <div className="month-summary-title">This Month</div>
+        <div className="month-summary-stat">
+          <span className="stat-number">{monthEventsCount}</span>
+          <span className="stat-label">Events</span>
+        </div>
+      </div>
+
       {/* Week Day Headers */}
       <div className="month-header">
         {weekDays.map((day) => (
@@ -68,7 +79,7 @@ const MonthView = () => {
               </div>
 
               <div className="day-events">
-                {dayEvents.slice(0, 3).map((event) => (
+                {dayEvents.slice(0, 4).map((event) => (
                   <motion.div
                     key={event.id}
                     initial={{ opacity: 0, x: -10 }}
@@ -78,15 +89,14 @@ const MonthView = () => {
                     className="day-event"
                     style={{ backgroundColor: event.color || getEventColor(event.category) }}
                   >
-                    <span className="event-title">
-                      {event.title}
-                    </span>
+                    <span className="event-time">{formatTime24(new Date(event.start))}</span>
+                    <span className="event-title">{event.title}</span>
                   </motion.div>
                 ))}
                 
-                {dayEvents.length > 3 && (
+                {dayEvents.length > 4 && (
                   <div className="more-events">
-                    +{dayEvents.length - 3} more
+                    +{dayEvents.length - 4} more
                   </div>
                 )}
               </div>

--- a/src/components/Calendar/WeekView.css
+++ b/src/components/Calendar/WeekView.css
@@ -8,6 +8,24 @@
   background: transparent;
 }
 
+.week-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 1.5rem;
+  margin-bottom: 1rem;
+}
+
+.week-summary-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.week-summary-stat {
+  text-align: center;
+}
+
 /* Header Grid */
 .week-header {
   display: grid;
@@ -18,6 +36,39 @@
   backdrop-filter: var(--backdrop-blur);
   z-index: 10;
   flex-shrink: 0;
+}
+
+.header-cell {
+  padding: 0.6rem 0.5rem;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.2rem;
+}
+
+.header-cell.today {
+  background: rgba(122, 162, 255, 0.15);
+}
+
+.day-name {
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--text-muted);
+}
+
+.day-num {
+  width: 28px;
+  height: 28px;
+  border-radius: 10px;
+  background: rgba(255, 255, 255, 0.08);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 0.9rem;
+  color: var(--text-primary);
 }
 
 /* ... */
@@ -62,10 +113,24 @@
   left: 60px;
   right: 0;
   height: 2px;
-  background: #ef4444;
+  background: linear-gradient(90deg, #fb7185, #f97316);
   z-index: 50;
   pointer-events: none;
   box-shadow: 0 0 6px rgba(239, 68, 68, 0.6);
+}
+
+.current-time-label {
+  position: absolute;
+  left: -56px;
+  top: -10px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #fde68a;
+  border: 1px solid rgba(251, 191, 36, 0.4);
+  padding: 2px 6px;
+  border-radius: 8px;
+  font-size: 0.7rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
 }
 
 .current-time-circle {

--- a/src/components/Calendar/WeekView.jsx
+++ b/src/components/Calendar/WeekView.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
-import { getWeekDays, getDayHours, formatTime, isToday } from '../../utils/dateUtils';
+import { getWeekDays, getDayHours, formatTime24, isToday } from '../../utils/dateUtils';
 import { useCalendar } from '../../contexts/CalendarContext';
 import { useEvents } from '../../contexts/EventsContext';
 import { cn, getEventColor } from '../../utils/helpers';
@@ -14,6 +14,7 @@ const WeekView = () => {
 
   const weekDays = getWeekDays(currentDate);
   const dayHours = getDayHours();
+  const weekEventsCount = weekDays.reduce((total, day) => total + getEventsForDate(day).length, 0);
 
   // Current Time Indicator Logic
   const [currentTimePos, setCurrentTimePos] = useState(null);
@@ -52,11 +53,20 @@ const WeekView = () => {
     if (distance === 0) return 6;    // Active
     if (distance === 1) return 2.5;  // Neighbors
     if (distance === 2) return 1.5;  // Far neighbors
+    if (distance === 3) return 1;    // Outer neighbors
     return 0.5;                      // Compressed
   };
 
   return (
     <div className="week-view" ref={containerRef}>
+      <div className="week-summary glass-card">
+        <div className="week-summary-title">This Week</div>
+        <div className="week-summary-stat">
+          <span className="stat-number">{weekEventsCount}</span>
+          <span className="stat-label">Events</span>
+        </div>
+      </div>
+
       {/* Header */}
       <div className="week-header glass-card">
         <div className="header-cell gutter"></div>
@@ -93,7 +103,7 @@ const WeekView = () => {
               onMouseEnter={() => setHoveredHour(hourNum)}
             >
               <div className="time-label">
-                {formatTime(hour).replace(':00', '')}
+                {formatTime24(hour)}
               </div>
 
               {/* Time Line (only if current hour) */}
@@ -103,6 +113,9 @@ const WeekView = () => {
                   style={{ top: `${currentMinPercent}%` }}
                 >
                   <div className="current-time-circle" />
+                  <div className="current-time-label">
+                    {formatTime24(now)}
+                  </div>
                 </div>
               )}
 

--- a/src/components/Calendar/YearView.css
+++ b/src/components/Calendar/YearView.css
@@ -1,0 +1,145 @@
+.year-view {
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.year-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 1.5rem 2rem;
+}
+
+.year-title h3 {
+  margin: 0;
+  font-size: 1.75rem;
+}
+
+.year-subtitle {
+  color: var(--text-secondary);
+  font-size: 0.95rem;
+}
+
+.year-grid {
+  padding: 1.5rem 2rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.year-month-labels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(10px, 1fr));
+  gap: 4px;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.month-label {
+  opacity: 0.2;
+}
+
+.month-label.visible {
+  opacity: 0.9;
+}
+
+.year-weeks {
+  display: grid;
+  grid-auto-flow: column;
+  grid-auto-columns: minmax(10px, 1fr);
+  gap: 4px;
+  align-items: start;
+}
+
+.year-week-column {
+  display: grid;
+  grid-template-rows: repeat(7, 1fr);
+  gap: 4px;
+}
+
+.year-day {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+  cursor: pointer;
+}
+
+.year-day.level-1 {
+  background: rgba(99, 102, 241, 0.35);
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+.year-day.level-2 {
+  background: rgba(96, 165, 250, 0.5);
+  border-color: rgba(96, 165, 250, 0.5);
+}
+
+.year-day.level-3 {
+  background: rgba(52, 211, 153, 0.55);
+  border-color: rgba(52, 211, 153, 0.55);
+}
+
+.year-day.level-4 {
+  background: rgba(34, 197, 94, 0.75);
+  border-color: rgba(34, 197, 94, 0.8);
+}
+
+.year-legend {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.legend-scale {
+  display: flex;
+  gap: 4px;
+}
+
+.legend-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  background: rgba(148, 163, 184, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.12);
+}
+
+.legend-dot.level-1 {
+  background: rgba(99, 102, 241, 0.35);
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+.legend-dot.level-2 {
+  background: rgba(96, 165, 250, 0.5);
+  border-color: rgba(96, 165, 250, 0.5);
+}
+
+.legend-dot.level-3 {
+  background: rgba(52, 211, 153, 0.55);
+  border-color: rgba(52, 211, 153, 0.55);
+}
+
+.legend-dot.level-4 {
+  background: rgba(34, 197, 94, 0.75);
+  border-color: rgba(34, 197, 94, 0.8);
+}
+
+@media (max-width: 1024px) {
+  .year-grid {
+    padding: 1.25rem;
+  }
+
+  .year-day,
+  .legend-dot {
+    width: 8px;
+    height: 8px;
+  }
+}

--- a/src/components/Calendar/YearView.jsx
+++ b/src/components/Calendar/YearView.jsx
@@ -1,0 +1,105 @@
+import { motion } from 'framer-motion';
+import { startOfYear, endOfYear, startOfWeek, endOfWeek, eachDayOfInterval, format } from 'date-fns';
+import { useCalendar } from '../../contexts/CalendarContext';
+import { useEvents } from '../../contexts/EventsContext';
+import { isSameMonth } from '../../utils/dateUtils';
+import { cn } from '../../utils/helpers';
+import './YearView.css';
+
+const WEEK_START = 0;
+
+const getCalendarWeeks = (date) => {
+  const yearStart = startOfYear(date);
+  const yearEnd = endOfYear(date);
+  const calendarStart = startOfWeek(yearStart, { weekStartsOn: WEEK_START });
+  const calendarEnd = endOfWeek(yearEnd, { weekStartsOn: WEEK_START });
+  const days = eachDayOfInterval({ start: calendarStart, end: calendarEnd });
+  const weeks = [];
+
+  for (let i = 0; i < days.length; i += 7) {
+    weeks.push(days.slice(i, i + 7));
+  }
+
+  return weeks;
+};
+
+const getIntensity = (count) => {
+  if (count >= 5) return 4;
+  if (count >= 3) return 3;
+  if (count >= 2) return 2;
+  if (count >= 1) return 1;
+  return 0;
+};
+
+const YearView = () => {
+  const { currentDate } = useCalendar();
+  const { getEventsForDate } = useEvents();
+
+  const weeks = getCalendarWeeks(currentDate);
+  const yearEventsCount = weeks.reduce((total, week) => {
+    return total + week.reduce((sum, day) => sum + getEventsForDate(day).length, 0);
+  }, 0);
+
+  return (
+    <div className="year-view">
+      <div className="year-header glass-card">
+        <div className="year-title">
+          <h3>{format(currentDate, 'yyyy')}</h3>
+          <span className="year-subtitle">Year Overview</span>
+        </div>
+        <div className="year-stats">
+          <div className="stat">
+            <span className="stat-number">{yearEventsCount}</span>
+            <span className="stat-label">Events</span>
+          </div>
+        </div>
+      </div>
+
+      <div className="year-grid glass-card">
+        <div className="year-month-labels">
+          {weeks.map((week, index) => {
+            const month = week[0];
+            const label = format(month, 'MMM');
+            const showLabel = index === 0 || !isSameMonth(month, weeks[index - 1][0]);
+            return (
+              <span key={`${label}-${index}`} className={cn('month-label', showLabel && 'visible')}>
+                {showLabel ? label : ''}
+              </span>
+            );
+          })}
+        </div>
+
+        <div className="year-weeks">
+          {weeks.map((week, index) => (
+            <div key={`week-${index}`} className="year-week-column">
+              {week.map((day) => {
+                const count = getEventsForDate(day).length;
+                const intensity = getIntensity(count);
+                return (
+                  <motion.div
+                    key={day.toISOString()}
+                    className={cn('year-day', intensity > 0 && `level-${intensity}`)}
+                    title={`${format(day, 'MMM d')} · ${count} event${count === 1 ? '' : 's'}`}
+                    whileHover={{ scale: 1.15 }}
+                  />
+                );
+              })}
+            </div>
+          ))}
+        </div>
+
+        <div className="year-legend">
+          <span>Less</span>
+          <div className="legend-scale">
+            {[0, 1, 2, 3, 4].map((level) => (
+              <span key={level} className={cn('legend-dot', level > 0 && `level-${level}`)} />
+            ))}
+          </div>
+          <span>More</span>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default YearView;

--- a/src/components/Events/EventModal.css
+++ b/src/components/Events/EventModal.css
@@ -95,6 +95,180 @@
   gap: 1rem;
 }
 
+.time-picker-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.clock-picker {
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  box-shadow: inset 0 0 20px rgba(15, 23, 42, 0.6);
+}
+
+.clock-picker-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.clock-label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  color: var(--text-secondary);
+}
+
+.clock-time-display {
+  font-size: 1rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  color: #e0e7ff;
+}
+
+.clock-face {
+  position: relative;
+  width: 200px;
+  height: 200px;
+  margin: 0 auto;
+  border-radius: 50%;
+  background: radial-gradient(circle at center, rgba(30, 64, 175, 0.2), rgba(15, 23, 42, 0.9));
+  border: 1px solid rgba(96, 165, 250, 0.35);
+  box-shadow: inset 0 0 30px rgba(59, 130, 246, 0.2), 0 8px 24px rgba(15, 23, 42, 0.6);
+  cursor: crosshair;
+  touch-action: none;
+}
+
+.clock-mark {
+  position: absolute;
+  top: 8px;
+  left: 50%;
+  width: 2px;
+  height: 12px;
+  transform-origin: center 92px;
+  background: rgba(148, 163, 184, 0.35);
+}
+
+.clock-mark.major {
+  height: 16px;
+  background: rgba(191, 219, 254, 0.8);
+}
+
+.mark-label {
+  position: absolute;
+  top: -16px;
+  left: 50%;
+  transform: translateX(-50%);
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: rgba(226, 232, 240, 0.8);
+}
+
+.clock-minute-dot {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  width: 3px;
+  height: 6px;
+  border-radius: 999px;
+  transform-origin: center 90px;
+  background: rgba(148, 163, 184, 0.35);
+}
+
+.clock-hand {
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  transform-origin: center;
+  transition: transform 0.15s ease;
+}
+
+.clock-hand span {
+  width: 2px;
+  height: 70px;
+  margin-top: 30px;
+  background: rgba(125, 211, 252, 0.7);
+  border-radius: 999px;
+  box-shadow: 0 0 10px rgba(59, 130, 246, 0.6);
+}
+
+.clock-hand.minute-hand span {
+  height: 80px;
+  margin-top: 20px;
+  background: rgba(251, 191, 36, 0.9);
+  box-shadow: 0 0 12px rgba(251, 191, 36, 0.6);
+}
+
+.clock-hand.active span {
+  width: 3px;
+}
+
+.clock-center {
+  position: absolute;
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+  background: #e0e7ff;
+  box-shadow: 0 0 12px rgba(99, 102, 241, 0.8);
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+}
+
+.clock-picker-footer {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.clock-action-btn {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(15, 23, 42, 0.6);
+  color: #cbd5f5;
+  border-radius: 10px;
+  padding: 4px 8px;
+  font-size: 0.7rem;
+  font-weight: 600;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.clock-action-btn:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.clock-action-btn.primary {
+  border-color: rgba(99, 102, 241, 0.6);
+  background: rgba(99, 102, 241, 0.25);
+  color: #e0e7ff;
+}
+
+.clock-action-btn:hover:not(:disabled) {
+  transform: translateY(-1px);
+  border-color: rgba(99, 102, 241, 0.6);
+}
+
+.clock-mode-indicator {
+  flex: 1;
+  text-align: center;
+  font-weight: 600;
+}
+
 .quick-duration {
   background: rgba(255, 255, 255, 0.03);
   border: 1px dashed rgba(148, 163, 184, 0.2);
@@ -235,6 +409,15 @@
   .form-row {
     grid-template-columns: 1fr;
     gap: 0;
+  }
+
+  .time-picker-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .clock-face {
+    width: 180px;
+    height: 180px;
   }
 
   .form-group {

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -15,7 +15,8 @@ const Header = ({ onOpenSettings, onOpenAI }) => {
   const viewButtons = [
     { key: CALENDAR_VIEWS.DAY, label: 'Day' },
     { key: CALENDAR_VIEWS.WEEK, label: 'Week' },
-    { key: CALENDAR_VIEWS.MONTH, label: 'Month' }
+    { key: CALENDAR_VIEWS.MONTH, label: 'Month' },
+    { key: CALENDAR_VIEWS.YEAR, label: 'Year' }
   ];
 
   const getHeaderTitle = () => {
@@ -26,6 +27,8 @@ const Header = ({ onOpenSettings, onOpenAI }) => {
         return formatDate(currentDate, 'MMMM yyyy');
       case CALENDAR_VIEWS.MONTH:
         return formatDate(currentDate, 'MMMM yyyy');
+      case CALENDAR_VIEWS.YEAR:
+        return formatDate(currentDate, 'yyyy');
       default:
         return formatDate(currentDate, 'MMMM yyyy');
     }
@@ -33,7 +36,7 @@ const Header = ({ onOpenSettings, onOpenAI }) => {
 
   const getSubTitle = () => {
     if (view === CALENDAR_VIEWS.DAY) {
-      return formatDate(currentDate, 'EEEE, d');
+      return formatDate(currentDate, 'EEEE, MMMM d, yyyy');
     }
     return null;
   };
@@ -166,7 +169,7 @@ const Header = ({ onOpenSettings, onOpenAI }) => {
                   whileHover={{ scale: 1.02 }}
                   whileTap={{ scale: 0.98 }}
                   onClick={() => setView(key)}
-                  className={`view - btn ${view === key ? 'active' : ''} `}
+                  className={`view-btn ${view === key ? 'active' : ''} `}
                 >
                   {label}
                 </motion.button>

--- a/src/components/Sidebar/UpcomingSidebar.css
+++ b/src/components/Sidebar/UpcomingSidebar.css
@@ -14,9 +14,65 @@
 
 .sidebar-header {
     display: flex;
-    justify-content: space-between;
-    align-items: center;
+    flex-direction: column;
+    gap: 0.75rem;
     margin-bottom: 24px;
+}
+
+.header-title-row {
+    display: grid;
+    grid-template-columns: 1fr auto 1fr;
+    align-items: center;
+    gap: 0.75rem;
+}
+
+.header-title-row h3 {
+    text-align: center;
+    letter-spacing: 0.02em;
+}
+
+.header-spacer {
+    width: 32px;
+    height: 32px;
+}
+
+.header-actions {
+    display: flex;
+    justify-content: flex-end;
+    gap: 0.5rem;
+}
+
+.icon-btn {
+    width: 32px;
+    height: 32px;
+    border-radius: 10px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(15, 23, 42, 0.4);
+    color: #c7d2fe;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.icon-btn:hover {
+    border-color: rgba(99, 102, 241, 0.45);
+    background: rgba(99, 102, 241, 0.15);
+    color: #e0e7ff;
+    transform: translateY(-1px);
+}
+
+.icon-btn.active {
+    border-color: rgba(99, 102, 241, 0.6);
+    background: rgba(99, 102, 241, 0.25);
+    color: #e0e7ff;
+}
+
+.icon-btn.active-red {
+    border-color: rgba(248, 113, 113, 0.5);
+    background: rgba(248, 113, 113, 0.15);
+    color: #fca5a5;
 }
 
 .category-filters {
@@ -63,6 +119,7 @@
     border-radius: 12px;
     font-size: 0.8rem;
     font-weight: 600;
+    align-self: center;
 }
 
 .upcoming-list {

--- a/src/components/Sidebar/UpcomingSidebar.jsx
+++ b/src/components/Sidebar/UpcomingSidebar.jsx
@@ -79,6 +79,7 @@ const UpcomingSidebar = () => {
         <div className="upcoming-sidebar glass-card">
             <div className="sidebar-header">
                 <div className="header-title-row">
+                    <span className="header-spacer" />
                     <h3>{viewMode === 'upcoming' ? 'Upcoming' : 'Archive'}</h3>
                     <div className="header-actions">
                         <button

--- a/src/contexts/CalendarContext.jsx
+++ b/src/contexts/CalendarContext.jsx
@@ -13,7 +13,8 @@ export const useCalendar = () => {
 export const CALENDAR_VIEWS = {
   DAY: 'day',
   WEEK: 'week',
-  MONTH: 'month'
+  MONTH: 'month',
+  YEAR: 'year'
 };
 
 export const CalendarProvider = ({ children }) => {
@@ -34,6 +35,9 @@ export const CalendarProvider = ({ children }) => {
           break;
         case CALENDAR_VIEWS.MONTH:
           newDate.setMonth(newDate.getMonth() + direction);
+          break;
+        case CALENDAR_VIEWS.YEAR:
+          newDate.setFullYear(newDate.getFullYear() + direction);
           break;
       }
       return newDate;

--- a/src/index.css
+++ b/src/index.css
@@ -5,24 +5,25 @@
   font-weight: 400;
 
   /* Global Colors */
-  --bg-primary: #050505;
-  /* Near black */
-  --bg-secondary: #0a0a0a;
-  /* Slightly lighter */
-  --accent: #6366f1;
-  /* Indigo 500 */
-  --accent-glow: rgba(99, 102, 241, 0.25);
+  --bg-primary: #0b1224;
+  /* Deep navy blue */
+  --bg-secondary: #101a33;
+  /* Soft blue slate */
+  --accent: #7aa2ff;
+  /* Soft blue */
+  --accent-hover: #91b4ff;
+  --accent-glow: rgba(122, 162, 255, 0.3);
 
   /* Text Contrast - Maximize legibility */
   --text-primary: #ffffff;
-  --text-secondary: #a3a3a3;
-  --text-muted: #737373;
+  --text-secondary: #c0c8da;
+  --text-muted: #8a93a5;
 
   /* Glass / Surfaces */
-  --glass-bg: rgba(10, 10, 10, 0.85);
-  --glass-border: rgba(255, 255, 255, 0.08);
+  --glass-bg: rgba(16, 26, 51, 0.82);
+  --glass-border: rgba(150, 170, 220, 0.15);
   /* White alpha border for contrast */
-  --glass-shadow: 0 4px 30px rgba(0, 0, 0, 0.5);
+  --glass-shadow: 0 12px 40px rgba(3, 7, 18, 0.5);
   --backdrop-blur: blur(16px);
 
   /* Status Colors */

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -23,6 +23,10 @@ export const formatTime = (date) => {
   return format(date, 'h:mm a');
 };
 
+export const formatTime24 = (date) => {
+  return format(date, 'HH:mm');
+};
+
 export const getWeekDays = (date) => {
   const start = startOfWeek(date, { weekStartsOn: 0 }); // Sunday
   const end = endOfWeek(date, { weekStartsOn: 0 });


### PR DESCRIPTION
### Motivation
- Provide a GitHub-style year overview and expose it in the main view switcher for a high-level events summary. 
- Improve readability and professionalism across month/week/day views with a lighter pastel blue theme, clearer time labels (24‑hour), and better event presentation. 
- Make event creation faster and more precise with a modern clock-face time picker, smarter defaults and quick-duration behavior tied to the selected start time. 

### Description
- Added a `YearView` component and styles and wired it into `Calendar.jsx`, `CalendarContext.jsx` and the header view switcher so `YEAR` is selectable from the header. 
- Introduced `formatTime24` in `src/utils/dateUtils.js` and switched day/week/month displays and current-time labels to 24‑hour formatting (`DayView.jsx`, `WeekView.jsx`, `MonthView.jsx`). 
- Implemented clock-based time picker UI and helpers in `EventModal.jsx` with new styles in `EventModal.css`, including drag/click selection, 5‑minute snapping, start/end pickers and rules to start hands at current time when creating events for today. 
- Improved month view event cards (more text, time label and larger sizing), added event counters/summary cards to week and month views, and centered the Upcoming/Archive title with redesigned sidebar controls (`UpcomingSidebar.*`). 
- Updated global theme colors to a softer blue/pastel palette and refreshed glass components and accents in `index.css`. 
- Ensured `Quick Duration` buttons compute end time by adding minutes to the current/selected start time (uses the form start value). 
- Small UX fixes: changed AI chat input placeholder to `Chat with Cal`, adjusted header subtitle to show full date under `Day` view, tuned fisheye scaling in week view and added the current-time numeric label to day/week views.

### Testing
- Started the dev server with `npm run dev` and the Vite server reported ready; an HTTP probe `curl -I http://127.0.0.1:4173` returned `200 OK`. (succeeded) 
- Attempted an automated Playwright UI capture to validate the modal and new clock picker, but Chromium crashed (SIGSEGV) in the environment so the screenshot run failed and no Playwright screenshot was produced. (failed)
- No unit or CI tests were run as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69686049a7b8832e9006e690479b1e8f)