### PR TITLE
Harden Gemini API key storage and UI masking

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -39,11 +39,8 @@ const MainLayout = () => {
 
   useEffect(() => {
     const initializeAI = async () => {
-      let key = localStorage.getItem('gemini_api_key');
-
-      // Using FirebaseService to fetch key if user is logged in
-      if (user && !key) {
-        // Dynamic import to avoid circular dependency issues if any, though here straightforward
+      let key = null;
+      if (user) {
         const { firebaseService } = await import('./services/firebaseService');
         key = await firebaseService.getApiKey();
       }


### PR DESCRIPTION
### Motivation
- Prevent accidental exposure of the Gemini API key in the browser UI and local persistence while retaining server-side persistence in Firebase.
- Make it possible to test and use a saved key without rendering the raw value in inputs.
- Reduce attack surface by clearing the visible input after a save and avoiding `localStorage` for long-lived key storage.

### Description
- Stop reading/writing `localStorage` for the Gemini API key and instead fetch the key from Firebase during app init via `firebaseService.getApiKey()` in `src/App.jsx`.
- In `src/components/Settings/Settings.jsx` store any retrieved/saved API key in a `useRef` (`savedApiKeyRef`) and track presence with `hasSavedApiKey` so the key is not displayed in the input.
- Change `testConnection` to prefer an explicit override or fall back to the hidden `savedApiKeyRef` so testing works without exposing the key, and initialize `geminiService` with the chosen key.
- After saving, persist the trimmed key to Firebase (when logged in), set the saved-ref, clear the visible input and hide it (`setApiKey('')`, `setShowApiKey(false)`), and show a small UI notice that the key is stored but hidden.

### Testing
- Started the dev server with `npm run dev`, which launched `vite` and reported the local/network URLs successfully (succeeded).
- Ran a Playwright script that loaded `http://127.0.0.1:4173/` and captured a screenshot of the app entrance page (succeeded).
- Committed the changes and created the PR after successful local verification steps (git commit succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696868df4aac832e84bad309d8756040)