### PR TITLE
Refine upcoming bulk delete UI

### DIFF
--- a/src/components/Sidebar/UpcomingSidebar.css
+++ b/src/components/Sidebar/UpcomingSidebar.css
@@ -82,6 +82,114 @@
     margin-bottom: 18px;
 }
 
+.delete-modal-area {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    padding: 16px;
+    border-radius: 16px;
+    background: rgba(15, 23, 42, 0.5);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    box-shadow: 0 12px 30px rgba(15, 23, 42, 0.35);
+}
+
+.delete-header {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.delete-title {
+    font-size: 0.9rem;
+    font-weight: 700;
+    color: #f1f5f9;
+}
+
+.delete-subtitle {
+    font-size: 0.75rem;
+    color: #94a3b8;
+}
+
+.delete-input-wrapper {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 10px;
+    border-radius: 12px;
+    border: 1px solid rgba(148, 163, 184, 0.25);
+    background: rgba(15, 23, 42, 0.65);
+}
+
+.delete-input-wrapper:focus-within {
+    border-color: rgba(99, 102, 241, 0.5);
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.15);
+}
+
+.delete-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    color: #e2e8f0;
+    font-size: 0.8rem;
+}
+
+.delete-input::placeholder {
+    color: #64748b;
+}
+
+.search-icon {
+    color: #94a3b8;
+}
+
+.close-btn {
+    width: 26px;
+    height: 26px;
+    border-radius: 8px;
+    border: 1px solid rgba(148, 163, 184, 0.2);
+    background: rgba(148, 163, 184, 0.1);
+    color: #94a3b8;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.close-btn:hover {
+    border-color: rgba(99, 102, 241, 0.5);
+    color: #e2e8f0;
+}
+
+.delete-confirm-btn {
+    border: none;
+    border-radius: 12px;
+    padding: 10px 12px;
+    font-size: 0.8rem;
+    font-weight: 700;
+    color: #fee2e2;
+    background: linear-gradient(135deg, rgba(248, 113, 113, 0.3), rgba(244, 63, 94, 0.5));
+    cursor: pointer;
+    transition: all 0.2s ease;
+}
+
+.delete-confirm-btn:disabled {
+    cursor: not-allowed;
+    background: rgba(148, 163, 184, 0.2);
+    color: #94a3b8;
+}
+
+.delete-confirm-btn:not(:disabled):hover {
+    transform: translateY(-1px);
+    box-shadow: 0 8px 18px rgba(248, 113, 113, 0.25);
+}
+
+.delete-hint {
+    margin: 0;
+    font-size: 0.7rem;
+    color: #94a3b8;
+}
+
 .filter-chip {
     border: 1px solid rgba(148, 163, 184, 0.2);
     background: rgba(15, 23, 42, 0.4);

--- a/src/components/Sidebar/UpcomingSidebar.jsx
+++ b/src/components/Sidebar/UpcomingSidebar.jsx
@@ -68,7 +68,7 @@ const UpcomingSidebar = () => {
 
     const handleBulkDelete = () => {
         if (!deleteSearch.trim()) return;
-        if (window.confirm(`Delete ALL events matching "${deleteSearch}"? This cannot be undone.`)) {
+        if (window.confirm(`Permanently delete all events titled "${deleteSearch}"? This cannot be undone.`)) {
             deleteEventsByName(deleteSearch);
             setDeleteSearch('');
             setShowDeleteModal(false);
@@ -131,11 +131,15 @@ const UpcomingSidebar = () => {
             {/* Delete By Name Modal/Area */}
             {showDeleteModal && (
                 <div className="delete-modal-area fade-in">
+                    <div className="delete-header">
+                        <span className="delete-title">Bulk delete by name</span>
+                        <span className="delete-subtitle">Remove every event with the exact title below.</span>
+                    </div>
                     <div className="delete-input-wrapper">
                         <Search size={14} className="search-icon" />
                         <input
                             type="text"
-                            placeholder="Event name to delete..."
+                            placeholder="Enter exact event title"
                             value={deleteSearch}
                             onChange={(e) => setDeleteSearch(e.target.value)}
                             className="delete-input"
@@ -149,9 +153,9 @@ const UpcomingSidebar = () => {
                         onClick={handleBulkDelete}
                         className="delete-confirm-btn"
                     >
-                        Delete All Matches
+                        Delete matching events
                     </button>
-                    <p className="delete-hint">Deletes ALL events with this title.</p>
+                    <p className="delete-hint">This action removes all events with the exact title.</p>
                 </div>
             )}
 


### PR DESCRIPTION
### Motivation
- Improve the tone and clarity of the bulk-delete experience in the Upcoming sidebar so it matches the app's glass-themed UI and reads more professional.
- Surface clearer, less alarming copy and provide a dedicated, styled area for bulk deletes to reduce accidental actions.

### Description
- Updated confirmation copy in `UpcomingSidebar.jsx` to `Permanently delete all events titled "<name>"? This cannot be undone.` to be clearer and more professional.
- Added a dedicated header and explanatory subtitle inside the bulk-delete area and adjusted placeholder and button labels to `Enter exact event title` and `Delete matching events` respectively in `UpcomingSidebar.jsx`.
- Implemented new themed styles in `UpcomingSidebar.css` for the bulk-delete panel, including `.delete-modal-area`, `.delete-header`, `.delete-input-wrapper`, `.delete-confirm-btn`, `.close-btn`, and related focus / disabled / hover states to match the glass UI.

### Testing
- Started the dev server with `npm run dev` and Vite reported ready (local and network URLs), which succeeded.
- Ran a Playwright script to capture the app landing screenshot and it completed successfully, producing `artifacts/app-home.png`.
- Attempted a Playwright interaction to click the sidebar delete icon and open the modal which timed out and failed to click the target during an automated run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69687a930e90832eaafa22cdec99b2a4)