### PR TITLE
Pastel UI, clock picker drag fixes, and interactive year view

### DIFF
--- a/src/components/AI/AIChat.jsx
+++ b/src/components/AI/AIChat.jsx
@@ -64,22 +64,12 @@ const AIChat = ({ isOpen, onClose }) => {
   const processInput = async (text) => {
     setIsLoading(true);
     try {
-      // First, check if this looks like an event request
-      const eventKeywords = ['schedule', 'create', 'add', 'book', 'appointment', 'meeting', 'reminder', 'event', 'tomorrow', 'next week', 'at'];
-      const isEventRequest = eventKeywords.some(keyword => text.toLowerCase().includes(keyword)) || text.length > 20; // Assume longer text might be "paste" content
-
-      if (isEventRequest) {
-        // ... (parsing logic remains similar but we handle the response more carefully)
-        try {
-          const eventData = await geminiService.parseEventFromText(text, events);
-          const conflicts = await geminiService.checkConflicts(eventData, events);
-          setPendingEvent({ ...eventData, conflicts, originalText: text });
-          addMessage('ai', "I've drafted this event for you. Does it look correct?");
-        } catch (error) {
-          const response = await geminiService.chatResponse(text, events);
-          handleAIResponse(response);
-        }
-      } else {
+      try {
+        const eventData = await geminiService.parseEventFromText(text, events);
+        const conflicts = await geminiService.checkConflicts(eventData, events);
+        setPendingEvent({ ...eventData, conflicts, originalText: text });
+        addMessage('ai', "I've drafted this event for you. Does it look correct?");
+      } catch (error) {
         const response = await geminiService.chatResponse(text, events);
         handleAIResponse(response);
       }
@@ -254,7 +244,7 @@ const AIChat = ({ isOpen, onClose }) => {
               type="text"
               value={inputValue}
               onChange={(e) => setInputValue(e.target.value)}
-              placeholder="Chat with Cal"
+              placeholder="just chat with cal"
               className="chat-input-field"
               autoFocus
             />

--- a/src/components/Calendar/DayView.css
+++ b/src/components/Calendar/DayView.css
@@ -60,7 +60,7 @@
 
 .day-grid {
   height: calc(var(--hour-height) * 24);
-  overflow: hidden;
+  overflow: visible;
   border-radius: 16px;
   background: var(--glass-border);
 }
@@ -69,14 +69,14 @@
   display: grid;
   grid-template-columns: 120px 1fr;
   height: 100%;
-  overflow-y: auto;
+  overflow: visible;
 }
 
 .time-column {
   background: var(--glass-bg);
   backdrop-filter: var(--backdrop-blur);
   -webkit-backdrop-filter: var(--backdrop-blur);
-  overflow: hidden;
+  overflow: visible;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.2) transparent;
 }
@@ -137,7 +137,7 @@
   background: var(--glass-bg);
   backdrop-filter: var(--backdrop-blur);
   -webkit-backdrop-filter: var(--backdrop-blur);
-  overflow: hidden;
+  overflow: visible;
   scroll-behavior: smooth;
   scrollbar-width: thin;
   scrollbar-color: rgba(255, 255, 255, 0.2) transparent;

--- a/src/components/Calendar/YearView.css
+++ b/src/components/Calendar/YearView.css
@@ -32,7 +32,7 @@
 
 .year-month-labels {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(10px, 1fr));
+  grid-template-columns: repeat(auto-fit, minmax(18px, 1fr));
   gap: 4px;
   font-size: 0.75rem;
   color: var(--text-muted);
@@ -51,7 +51,7 @@
 .year-weeks {
   display: grid;
   grid-auto-flow: column;
-  grid-auto-columns: minmax(10px, 1fr);
+  grid-auto-columns: minmax(18px, 1fr);
   gap: 4px;
   align-items: start;
 }
@@ -63,32 +63,42 @@
 }
 
 .year-day {
-  width: 10px;
-  height: 10px;
-  border-radius: 3px;
-  background: rgba(148, 163, 184, 0.12);
-  border: 1px solid rgba(148, 163, 184, 0.12);
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  background: rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.25);
   cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.6rem;
+  font-weight: 700;
+  color: var(--text-primary);
 }
 
 .year-day.level-1 {
-  background: rgba(99, 102, 241, 0.35);
-  border-color: rgba(99, 102, 241, 0.4);
+  background: rgba(167, 197, 255, 0.4);
+  border-color: rgba(167, 197, 255, 0.6);
 }
 
 .year-day.level-2 {
-  background: rgba(96, 165, 250, 0.5);
-  border-color: rgba(96, 165, 250, 0.5);
+  background: rgba(186, 230, 253, 0.55);
+  border-color: rgba(186, 230, 253, 0.7);
 }
 
 .year-day.level-3 {
-  background: rgba(52, 211, 153, 0.55);
-  border-color: rgba(52, 211, 153, 0.55);
+  background: rgba(216, 180, 254, 0.6);
+  border-color: rgba(216, 180, 254, 0.7);
 }
 
 .year-day.level-4 {
-  background: rgba(34, 197, 94, 0.75);
-  border-color: rgba(34, 197, 94, 0.8);
+  background: rgba(253, 186, 248, 0.7);
+  border-color: rgba(253, 186, 248, 0.8);
+}
+
+.year-day-count {
+  line-height: 1;
 }
 
 .year-legend {
@@ -105,31 +115,31 @@
 }
 
 .legend-dot {
-  width: 10px;
-  height: 10px;
-  border-radius: 3px;
-  background: rgba(148, 163, 184, 0.12);
-  border: 1px solid rgba(148, 163, 184, 0.12);
+  width: 18px;
+  height: 18px;
+  border-radius: 6px;
+  background: rgba(148, 163, 184, 0.2);
+  border: 1px solid rgba(148, 163, 184, 0.25);
 }
 
 .legend-dot.level-1 {
-  background: rgba(99, 102, 241, 0.35);
-  border-color: rgba(99, 102, 241, 0.4);
+  background: rgba(167, 197, 255, 0.4);
+  border-color: rgba(167, 197, 255, 0.6);
 }
 
 .legend-dot.level-2 {
-  background: rgba(96, 165, 250, 0.5);
-  border-color: rgba(96, 165, 250, 0.5);
+  background: rgba(186, 230, 253, 0.55);
+  border-color: rgba(186, 230, 253, 0.7);
 }
 
 .legend-dot.level-3 {
-  background: rgba(52, 211, 153, 0.55);
-  border-color: rgba(52, 211, 153, 0.55);
+  background: rgba(216, 180, 254, 0.6);
+  border-color: rgba(216, 180, 254, 0.7);
 }
 
 .legend-dot.level-4 {
-  background: rgba(34, 197, 94, 0.75);
-  border-color: rgba(34, 197, 94, 0.8);
+  background: rgba(253, 186, 248, 0.7);
+  border-color: rgba(253, 186, 248, 0.8);
 }
 
 @media (max-width: 1024px) {
@@ -139,7 +149,7 @@
 
   .year-day,
   .legend-dot {
-    width: 8px;
-    height: 8px;
+    width: 14px;
+    height: 14px;
   }
 }

--- a/src/components/Events/EventModal.css
+++ b/src/components/Events/EventModal.css
@@ -103,14 +103,14 @@
 }
 
 .clock-picker {
-  background: rgba(15, 23, 42, 0.35);
-  border: 1px solid rgba(148, 163, 184, 0.2);
+  background: rgba(255, 255, 255, 0.7);
+  border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 16px;
   padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
-  box-shadow: inset 0 0 20px rgba(15, 23, 42, 0.6);
+  box-shadow: inset 0 0 20px rgba(148, 163, 184, 0.25);
 }
 
 .clock-picker-header {
@@ -129,7 +129,7 @@
   font-size: 1rem;
   font-weight: 700;
   letter-spacing: 0.08em;
-  color: #e0e7ff;
+  color: var(--text-primary);
 }
 
 .clock-face {
@@ -138,11 +138,12 @@
   height: 200px;
   margin: 0 auto;
   border-radius: 50%;
-  background: radial-gradient(circle at center, rgba(30, 64, 175, 0.2), rgba(15, 23, 42, 0.9));
-  border: 1px solid rgba(96, 165, 250, 0.35);
-  box-shadow: inset 0 0 30px rgba(59, 130, 246, 0.2), 0 8px 24px rgba(15, 23, 42, 0.6);
+  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.9), rgba(226, 232, 240, 0.9));
+  border: 1px solid rgba(148, 163, 184, 0.5);
+  box-shadow: inset 0 0 24px rgba(148, 163, 184, 0.25), 0 8px 20px rgba(148, 163, 184, 0.25);
   cursor: crosshair;
   touch-action: none;
+  user-select: none;
 }
 
 .clock-mark {
@@ -152,12 +153,13 @@
   width: 2px;
   height: 12px;
   transform-origin: center 92px;
-  background: rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.55);
+  user-select: none;
 }
 
 .clock-mark.major {
   height: 16px;
-  background: rgba(191, 219, 254, 0.8);
+  background: rgba(99, 102, 241, 0.55);
 }
 
 .mark-label {
@@ -167,7 +169,8 @@
   transform: translateX(-50%);
   font-size: 0.6rem;
   font-weight: 700;
-  color: rgba(226, 232, 240, 0.8);
+  color: rgba(71, 85, 105, 0.9);
+  user-select: none;
 }
 
 .clock-minute-dot {
@@ -178,7 +181,8 @@
   height: 6px;
   border-radius: 999px;
   transform-origin: center 90px;
-  background: rgba(148, 163, 184, 0.35);
+  background: rgba(148, 163, 184, 0.5);
+  user-select: none;
 }
 
 .clock-hand {
@@ -195,16 +199,16 @@
   width: 2px;
   height: 70px;
   margin-top: 30px;
-  background: rgba(125, 211, 252, 0.7);
+  background: rgba(59, 130, 246, 0.6);
   border-radius: 999px;
-  box-shadow: 0 0 10px rgba(59, 130, 246, 0.6);
+  box-shadow: 0 0 8px rgba(59, 130, 246, 0.4);
 }
 
 .clock-hand.minute-hand span {
   height: 80px;
   margin-top: 20px;
-  background: rgba(251, 191, 36, 0.9);
-  box-shadow: 0 0 12px rgba(251, 191, 36, 0.6);
+  background: rgba(251, 191, 36, 0.8);
+  box-shadow: 0 0 10px rgba(251, 191, 36, 0.5);
 }
 
 .clock-hand.active span {
@@ -216,8 +220,8 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #e0e7ff;
-  box-shadow: 0 0 12px rgba(99, 102, 241, 0.8);
+  background: #ffffff;
+  box-shadow: 0 0 10px rgba(99, 102, 241, 0.35);
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
@@ -233,9 +237,9 @@
 }
 
 .clock-action-btn {
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(15, 23, 42, 0.6);
-  color: #cbd5f5;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--text-secondary);
   border-radius: 10px;
   padding: 4px 8px;
   font-size: 0.7rem;
@@ -253,9 +257,9 @@
 }
 
 .clock-action-btn.primary {
-  border-color: rgba(99, 102, 241, 0.6);
-  background: rgba(99, 102, 241, 0.25);
-  color: #e0e7ff;
+  border-color: rgba(129, 140, 248, 0.7);
+  background: rgba(129, 140, 248, 0.2);
+  color: rgba(67, 56, 202, 0.9);
 }
 
 .clock-action-btn:hover:not(:disabled) {
@@ -270,8 +274,8 @@
 }
 
 .quick-duration {
-  background: rgba(255, 255, 255, 0.03);
-  border: 1px dashed rgba(148, 163, 184, 0.2);
+  background: rgba(255, 255, 255, 0.6);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
   padding: 0.75rem 1rem;
   border-radius: 12px;
 }
@@ -283,9 +287,9 @@
 }
 
 .duration-btn {
-  border: 1px solid rgba(148, 163, 184, 0.3);
-  background: rgba(15, 23, 42, 0.4);
-  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(255, 255, 255, 0.7);
+  color: var(--text-primary);
   font-size: 0.8rem;
   font-weight: 600;
   padding: 0.35rem 0.6rem;
@@ -295,8 +299,8 @@
 }
 
 .duration-btn:hover {
-  border-color: rgba(99, 102, 241, 0.6);
-  color: #c7d2fe;
+  border-color: rgba(129, 140, 248, 0.7);
+  color: rgba(67, 56, 202, 0.9);
   transform: translateY(-1px);
 }
 
@@ -308,9 +312,9 @@
 }
 
 .category-pill {
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(15, 23, 42, 0.4);
-  color: #e2e8f0;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(255, 255, 255, 0.65);
+  color: var(--text-primary);
   font-size: 0.75rem;
   font-weight: 600;
   padding: 0.35rem 0.6rem;
@@ -326,8 +330,8 @@
 }
 
 .category-pill:hover {
-  border-color: rgba(99, 102, 241, 0.6);
-  color: #c7d2fe;
+  border-color: rgba(129, 140, 248, 0.7);
+  color: rgba(67, 56, 202, 0.9);
   transform: translateY(-1px);
 }
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,30 +1,30 @@
-/* Pro High-Contrast Dark Theme */
+/* Pastel Light Theme */
 :root {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   line-height: 1.6;
   font-weight: 400;
 
   /* Global Colors */
-  --bg-primary: #0b1224;
-  /* Deep navy blue */
-  --bg-secondary: #101a33;
-  /* Soft blue slate */
-  --accent: #7aa2ff;
-  /* Soft blue */
-  --accent-hover: #91b4ff;
-  --accent-glow: rgba(122, 162, 255, 0.3);
+  --bg-primary: #f7f7ff;
+  /* Soft lavender white */
+  --bg-secondary: #eef2ff;
+  /* Pastel blue */
+  --accent: #a7c5ff;
+  /* Pastel blue */
+  --accent-hover: #bdd3ff;
+  --accent-glow: rgba(167, 197, 255, 0.45);
 
   /* Text Contrast - Maximize legibility */
-  --text-primary: #ffffff;
-  --text-secondary: #c0c8da;
-  --text-muted: #8a93a5;
+  --text-primary: #1f2937;
+  --text-secondary: #4b5563;
+  --text-muted: #6b7280;
 
   /* Glass / Surfaces */
-  --glass-bg: rgba(16, 26, 51, 0.82);
-  --glass-border: rgba(150, 170, 220, 0.15);
-  /* White alpha border for contrast */
-  --glass-shadow: 0 12px 40px rgba(3, 7, 18, 0.5);
-  --backdrop-blur: blur(16px);
+  --glass-bg: rgba(255, 255, 255, 0.75);
+  --glass-border: rgba(148, 163, 184, 0.35);
+  /* Soft pastel border */
+  --glass-shadow: 0 12px 32px rgba(148, 163, 184, 0.25);
+  --backdrop-blur: blur(14px);
 
   /* Status Colors */
   --success: #10b981;


### PR DESCRIPTION
### Motivation
- Refresh the app to a lighter pastel visual style and make event creation UI match that theme for a softer look.
- Fix clock time picker interactions so dragging works reliably, `Done`/`Back` behave correctly, and both hour and minute hands can be dragged.
- Make the year view usable: stable month labels, clickable days to create events, and visible per-day event counts drawn in the day color.

### Description
- Updated global palette and surface variables in `src/index.css` to a pastel/light theme and adjusted glass surface tokens to lighter values.
- Restyled the event modal clock in `src/components/Events/EventModal.css` to match the pastel UI and reduced heavy dark/glow visuals.
- Fixed the clock picker interaction in `src/components/Events/EventModal.jsx` by adding `modeRef`, pointer capture/release handling, preventing unwanted mode switches while dragging, and ensuring `Back`/`Done` clear drag state.
- Made year view changes in `src/components/Calendar/YearView.jsx` and `YearView.css` to show stable month labels (using `Intl.DateTimeFormat`), render per-day event counts, color days using the first event color via an `rgba` helper, and make days clickable to open the event modal at midday; increased day cell size for readability.
- Removed internal scrolling in the day grid by changing overflow rules in `src/components/Calendar/DayView.css` so the full schedule renders without needing to scroll inside that container.
- Unified AI chat input behavior in `src/components/AI/AIChat.jsx` to attempt event parsing first (with fallback to chat response) and changed the chat placeholder to "just chat with cal".

### Testing
- Started the dev server with `npm run dev` and confirmed Vite served the app successfully (local and network URLs printed); this succeeded.
- Ran a headless Playwright script to load the app and capture a screenshot to exercise the updated UI, producing `artifacts/pastel-ui.png`; the script completed successfully.
- No unit or integration test suites were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69687e694418832ebc6a0e75f0555454)