### PR TITLE
Improve day view scaling, time alignment, and hover magnification

### DIFF
--- a/src/components/Calendar/DayView.css
+++ b/src/components/Calendar/DayView.css
@@ -69,7 +69,7 @@
   display: grid;
   grid-template-columns: 120px 1fr;
   height: 100%;
-  overflow-y: auto;
+  overflow: hidden;
 }
 
 .time-column {
@@ -102,6 +102,7 @@
   align-items: flex-start;
   justify-content: flex-end;
   position: relative;
+  transition: background-color 0.2s ease, transform 0.2s ease;
 }
 
 .time-slot.half-hour {
@@ -123,6 +124,7 @@
   padding: 0.25rem 0.5rem;
   border-radius: 6px;
   border: 1px solid var(--glass-border);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
 .time-label-half {
@@ -130,6 +132,16 @@
   color: var(--text-muted);
   opacity: 0.6;
   transform: translateY(-4px);
+}
+
+.time-slot:hover {
+  background: rgba(99, 102, 241, 0.12);
+  transform: scale(1.02);
+}
+
+.time-slot:hover .time-label {
+  transform: translateY(-10px) scale(1.08);
+  box-shadow: 0 6px 20px rgba(15, 23, 42, 0.25);
 }
 
 .events-column {
@@ -186,6 +198,29 @@
   height: 1px;
   background: rgba(255, 255, 255, 0.05);
   pointer-events: none;
+}
+
+.hour-slot::after {
+  content: attr(data-time);
+  position: absolute;
+  top: 0.35rem;
+  left: 0.75rem;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.9);
+  color: #e2e8f0;
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  opacity: 0;
+  transform: scale(0.9);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+  pointer-events: none;
+}
+
+.hour-slot:hover::after {
+  opacity: 1;
+  transform: scale(1.05);
 }
 
 .current-time-indicator {

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -68,10 +68,10 @@ export const getDayHoursWithHalf = () => {
   return slots;
 };
 
-export const getCurrentTimePosition = () => {
+export const getCurrentTimePosition = (pixelsPerHour = 36) => {
   const now = new Date();
   const minutes = now.getHours() * 60 + now.getMinutes();
-  return (minutes / 60) * 36; // 36px per hour slot
+  return (minutes / 60) * pixelsPerHour;
 };
 
 export const isBusinessHour = (hour) => {
@@ -83,15 +83,16 @@ export const isDateInRange = (date, start, end) => {
   return date >= start && date <= end;
 };
 
-export const getEventPosition = (event, dayStart) => {
+export const getEventPosition = (event, dayStart, pixelsPerHour = 36) => {
   const eventStart = new Date(event.start);
   const eventEnd = new Date(event.end);
   
   const minutesFromDayStart = (eventStart.getHours() * 60) + eventStart.getMinutes();
   const duration = (eventEnd - eventStart) / (1000 * 60); // duration in minutes
   
-  const top = (minutesFromDayStart / 60) * 36; // 36px per hour
-  const height = Math.max((duration / 60) * 36, 24); // minimum 24px height
+  const top = (minutesFromDayStart / 60) * pixelsPerHour;
+  const minHeight = Math.max(pixelsPerHour * 0.45, 12);
+  const height = Math.max((duration / 60) * pixelsPerHour, minHeight);
   
   return { top, height };
 };


### PR DESCRIPTION
### Motivation
- Make the day view show all 24 hours without internal scrolling and fix mismatched event/current-time positioning by computing a viewport-aware hour scale. 

### Description
- Compute a dynamic `pixelsPerHour` in `DayView.jsx` via `useLayoutEffect` and expose it as CSS variables `--hour-height` and `--half-hour-height` so the grid fills the available viewport height. 
- Change `getCurrentTimePosition` and `getEventPosition` signatures in `src/utils/dateUtils.js` to accept `pixelsPerHour` and compute `top` and `height` relative to the dynamic scale, adding a proportional `minHeight` for small events. 
- Use the computed `pixelsPerHour` when rendering the current-time indicator and events in `DayView.jsx` and stop forcing an arbitrary clamped height so event positioning aligns with time labels. 
- Update `DayView.css` to remove internal scrolling of the grid, add hover magnification cues and animated time callouts for hour slots, and tweak related styles for a smoother interactive feel. 

### Testing
- Started the dev server with `npm run dev` (Vite ready) and the command completed successfully. 
- Captured a visual verification screenshot using a Playwright script targeting `http://127.0.0.1:4173/`, which ran successfully and wrote `artifacts/day-view.png`. 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69687ecb4374832e83937736a7d97176)