### PR TITLE
Upgrade local brain model and grounding prompts

### DIFF
--- a/src/components/Settings/Settings.jsx
+++ b/src/components/Settings/Settings.jsx
@@ -409,7 +409,7 @@ const Settings = ({ isOpen, onClose }) => {
                         {!isLocalBrainLoaded && !localBrainProgress && (
                           <div style={{ marginTop: '12px' }}>
                             <p style={{ fontSize: '12px', color: '#aaa', marginBottom: '8px' }}>
-                              Requires ~400MB download (first time only). Uses your device's GPU.
+                              Requires ~1.5GB download (first time only). Uses your device's GPU.
                             </p>
                             <button onClick={handleInitLocalBrain} className="pro-btn-secondary">
                               <Download size={14} /> Initialize Backup Brain
@@ -429,7 +429,7 @@ const Settings = ({ isOpen, onClose }) => {
                         {isLocalBrainLoaded && (
                           <>
                             <div style={{ marginTop: '12px', display: 'flex', alignItems: 'center', gap: '8px' }}>
-                              <div className="pro-status success"><CheckCircle size={14} /> Ready (Qwen 0.5B)</div>
+                              <div className="pro-status success"><CheckCircle size={14} /> Ready (Qwen 2.5 3B)</div>
                               <button onClick={handleUnloadBrain} className="danger-link" style={{ marginLeft: 'auto', fontSize: '11px' }}>
                                 Unload
                               </button>


### PR DESCRIPTION
### Motivation

- Improve the offline/local model quality so the app can parse events and times more reliably without Gemini. 
- Provide explicit grounding (current date/time and timezone) so the local model interprets relative times like "tomorrow" or "8am" correctly.
- Surface the model change in the Settings UI so users understand the download/size and model label.

### Description

- Switched the local WebLLM selection from `Qwen2.5-0.5B-Instruct-q4f16_1-MLC` to `Qwen2.5-3B-Instruct-q4f16_1-MLC` to improve reasoning and parsing. 
- Added `getTemporalContext()` and `getGroundingPrompt()` helpers and wired `getGroundingPrompt()` as the default system instruction for `localBrainService.chat()` to inject local date/time and timezone context. 
- Updated `localBrainService.parseEvent()` prompt to include explicit grounding, timezone, parsing rules, JSON-only output instructions, and category extraction. 
- Updated Settings copy to reflect the larger download size and new model label (`Requires ~1.5GB` and `Ready (Qwen 2.5 3B)`).

### Testing

- Started the dev server with `npm run dev` and the Vite server reported ready (local and network URLs served). 
- Ran a Playwright script to open the app and capture the AI Engine settings UI, producing a screenshot artifact at `artifacts/ai-engine-offline-brain.png`. 
- No unit tests were executed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69692ae535e0832e926ca657c8888e83)