### PR TITLE
Finalize magnify focus, add image-based AI parsing, themes & general event packs

### DIFF
--- a/src/components/AI/AIChat.css
+++ b/src/components/AI/AIChat.css
@@ -82,6 +82,10 @@
   color: #f97316;
 }
 
+.chat-status.info {
+  color: #38bdf8;
+}
+
 .chat-title h3 {
   font-size: 1rem;
   font-weight: 600;
@@ -205,6 +209,14 @@
   gap: 0.75rem;
 }
 
+.image-event-batch {
+  border-style: dashed;
+}
+
+.image-event-actions {
+  margin-top: 0.75rem;
+}
+
 .btn-icon {
   display: flex;
   align-items: center;
@@ -237,6 +249,35 @@
   display: flex;
   gap: 0.75rem;
   align-items: center;
+}
+
+.chat-image-input {
+  display: none;
+}
+
+.chat-upload-btn {
+  width: 44px;
+  height: 44px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  cursor: pointer;
+  color: var(--text-secondary);
+  transition: all 0.2s ease;
+}
+
+.chat-upload-btn:hover:not(:disabled) {
+  border-color: var(--accent);
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.chat-upload-btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
 }
 
 .chat-input-field {

--- a/src/components/Calendar/DayView.css
+++ b/src/components/Calendar/DayView.css
@@ -103,6 +103,7 @@
   justify-content: flex-end;
   position: relative;
   transition: background-color 0.2s ease, transform 0.2s ease;
+  --magnify-scale: 1;
 }
 
 .time-slot.half-hour {
@@ -136,12 +137,39 @@
 
 .time-slot:hover {
   background: rgba(99, 102, 241, 0.12);
-  transform: scale(1.02);
+  transform: scale(1.02) scaleY(var(--magnify-scale));
 }
 
 .time-slot:hover .time-label {
   transform: translateY(-10px) scale(1.08);
   box-shadow: 0 6px 20px rgba(15, 23, 42, 0.25);
+}
+
+.time-slot.magnify-core {
+  background: rgba(56, 189, 248, 0.12);
+  --magnify-scale: 1.08;
+  transform: scaleY(var(--magnify-scale));
+}
+
+.time-slot.magnify-near {
+  background: rgba(56, 189, 248, 0.08);
+  --magnify-scale: 1.05;
+  transform: scaleY(var(--magnify-scale));
+}
+
+.time-slot.magnify-far {
+  background: rgba(56, 189, 248, 0.04);
+  --magnify-scale: 1.02;
+  transform: scaleY(var(--magnify-scale));
+}
+
+.time-slot.magnify-core .time-label {
+  transform: translateY(-12px) scale(1.12);
+  box-shadow: 0 8px 24px rgba(56, 189, 248, 0.25);
+}
+
+.time-slot.magnify-near .time-label {
+  transform: translateY(-9px) scale(1.08);
 }
 
 .events-column {
@@ -203,6 +231,7 @@
   cursor: pointer;
   transition: background-color 0.2s ease;
   position: relative;
+  --magnify-scale: 1;
 }
 
 .hour-slot.business-hour {
@@ -211,6 +240,22 @@
 
 .hour-slot:hover {
   background: rgba(255, 255, 255, 0.05);
+  transform: scaleY(var(--magnify-scale));
+}
+
+.hour-slot.magnify-core {
+  background: rgba(56, 189, 248, 0.08);
+  --magnify-scale: 1.08;
+}
+
+.hour-slot.magnify-near {
+  background: rgba(56, 189, 248, 0.04);
+  --magnify-scale: 1.05;
+}
+
+.hour-slot.magnify-far {
+  background: rgba(56, 189, 248, 0.02);
+  --magnify-scale: 1.02;
 }
 
 .hour-slot::before {
@@ -316,6 +361,12 @@
   backdrop-filter: blur(8px);
   -webkit-backdrop-filter: blur(8px);
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.1);
+}
+
+.day-event.past-event {
+  opacity: 0.55;
+  filter: grayscale(0.4);
+  transform: scale(0.97);
 }
 
 .day-event:hover {

--- a/src/components/Calendar/MonthView.css
+++ b/src/components/Calendar/MonthView.css
@@ -129,6 +129,12 @@
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
+.day-event.past-event {
+  opacity: 0.55;
+  filter: grayscale(0.4);
+  transform: scale(0.96);
+}
+
 .event-title {
   display: block;
   overflow: hidden;

--- a/src/components/Calendar/MonthView.jsx
+++ b/src/components/Calendar/MonthView.jsx
@@ -8,6 +8,7 @@ import './MonthView.css';
 const MonthView = () => {
   const { currentDate, openEventModal, setView, setCurrentDate } = useCalendar();
   const { getEventsForDate } = useEvents();
+  const now = new Date();
 
   const monthDays = getMonthDays(currentDate);
   const weekDays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat'];
@@ -86,7 +87,7 @@ const MonthView = () => {
                     animate={{ opacity: 1, x: 0 }}
                     whileHover={{ scale: 1.02 }}
                     onClick={(e) => handleEventClick(event, e)}
-                    className="day-event"
+                    className={cn('day-event', new Date(event.end || event.start) < now && 'past-event')}
                     style={{ backgroundColor: event.color || getEventColor(event.category) }}
                   >
                     <span className="event-time">{formatTime24(new Date(event.start))}</span>

--- a/src/components/Calendar/WeekView.css
+++ b/src/components/Calendar/WeekView.css
@@ -96,6 +96,26 @@
   font-size: 0.75rem;
   color: var(--text-muted);
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+  --magnify-scale: 1;
+}
+
+.week-time-slot.magnify-core {
+  color: var(--text-primary);
+  background: rgba(56, 189, 248, 0.1);
+  --magnify-scale: 1.08;
+  transform: scaleY(var(--magnify-scale));
+}
+
+.week-time-slot.magnify-near {
+  background: rgba(56, 189, 248, 0.05);
+  --magnify-scale: 1.05;
+  transform: scaleY(var(--magnify-scale));
+}
+
+.week-time-slot.magnify-far {
+  background: rgba(56, 189, 248, 0.03);
+  --magnify-scale: 1.02;
+  transform: scaleY(var(--magnify-scale));
 }
 
 .week-days-grid {
@@ -119,10 +139,27 @@
   border-bottom: 1px solid rgba(255, 255, 255, 0.05);
   cursor: pointer;
   transition: background 0.2s ease;
+  --magnify-scale: 1;
 }
 
 .week-hour-cell:hover {
   background: rgba(255, 255, 255, 0.05);
+  transform: scaleY(var(--magnify-scale));
+}
+
+.week-hour-cell.magnify-core {
+  background: rgba(56, 189, 248, 0.08);
+  --magnify-scale: 1.08;
+}
+
+.week-hour-cell.magnify-near {
+  background: rgba(56, 189, 248, 0.04);
+  --magnify-scale: 1.05;
+}
+
+.week-hour-cell.magnify-far {
+  background: rgba(56, 189, 248, 0.02);
+  --magnify-scale: 1.02;
 }
 
 .week-events-layer {
@@ -143,6 +180,12 @@
   pointer-events: auto;
   overflow: hidden;
   backdrop-filter: blur(6px);
+}
+
+.week-event.past-event {
+  opacity: 0.55;
+  filter: grayscale(0.4);
+  transform: scale(0.97);
 }
 
 .week-event-title {

--- a/src/components/Common/ThemeBackground.jsx
+++ b/src/components/Common/ThemeBackground.jsx
@@ -6,7 +6,7 @@ const ThemeBackground = () => {
     const canvasRef = useRef(null);
 
     useEffect(() => {
-        if (theme !== 'quantum' && theme !== 'neon') return;
+        if (theme !== 'codex' && theme !== 'pastel' && theme !== 'white') return;
 
         const canvas = canvasRef.current;
         if (!canvas) return;
@@ -26,24 +26,24 @@ const ThemeBackground = () => {
             mouse.y = e.clientY;
         };
 
+        resize();
+        window.addEventListener('resize', resize);
         window.addEventListener('mousemove', handleMouseMove);
 
         // Particle system (Subtle & Ambient)
         const particles = [];
-        const isLiving = theme === 'living';
-        // drastically reduced counts for "less chaos"
-        const particleCount = theme === 'quantum' ? 20 : (isLiving ? 25 : 15);
-        const color = theme === 'quantum' ? '139, 92, 246' : (isLiving ? '244, 114, 182' : '0, 242, 255');
+        const particleCount = theme === 'codex' ? 24 : theme === 'pastel' ? 20 : 14;
+        const color = theme === 'codex' ? '56, 189, 248' : theme === 'pastel' ? '236, 72, 153' : '100, 116, 139';
+        const glow = theme === 'codex' ? 0.35 : theme === 'pastel' ? 0.28 : 0.2;
 
         for (let i = 0; i < particleCount; i++) {
             particles.push({
                 x: Math.random() * canvas.width,
                 y: Math.random() * canvas.height,
-                size: Math.random() * (isLiving ? 2.5 : 1.5) + 0.5,
-                // Slower, calmer movement
-                speedX: Math.random() * 0.2 - 0.1,
-                speedY: Math.random() * 0.2 - 0.1,
-                opacity: Math.random() * 0.3 + 0.1 // Lower opacity
+                size: Math.random() * (theme === 'pastel' ? 3 : 2) + 0.5,
+                speedX: Math.random() * 0.18 - 0.09,
+                speedY: Math.random() * 0.18 - 0.09,
+                opacity: Math.random() * glow + 0.08
             });
         }
 
@@ -54,19 +54,18 @@ const ThemeBackground = () => {
                 p.x += p.speedX;
                 p.y += p.speedY;
 
-                // Mouse interaction for living theme
-                if (isLiving) {
+                if (theme === 'pastel') {
                     const dx = mouse.x - p.x;
                     const dy = mouse.y - p.y;
                     const distance = Math.sqrt(dx * dx + dy * dy);
                     const forceDirectionX = dx / distance;
                     const forceDirectionY = dy / distance;
-                    const maxDistance = 150;
+                    const maxDistance = 120;
                     const force = (maxDistance - distance) / maxDistance;
 
                     if (distance < maxDistance) {
-                        p.x -= forceDirectionX * force * 2;
-                        p.y -= forceDirectionY * force * 2;
+                        p.x -= forceDirectionX * force * 1.5;
+                        p.y -= forceDirectionY * force * 1.5;
                     }
                 }
 
@@ -78,17 +77,17 @@ const ThemeBackground = () => {
                 ctx.fillStyle = `rgba(${color}, ${p.opacity})`;
                 ctx.fill();
 
-                // Lines between close particles
-                if (!isLiving && theme === 'quantum') {
+                // Lines between close particles (codex tech grid feel)
+                if (theme === 'codex') {
                     for (let j = i + 1; j < particles.length; j++) {
                         const p2 = particles[j];
                         const dx = p.x - p2.x;
                         const dy = p.y - p2.y;
                         const dist = Math.sqrt(dx * dx + dy * dy);
 
-                        if (dist < 150) {
+                        if (dist < 160) {
                             ctx.beginPath();
-                            ctx.strokeStyle = `rgba(${color}, ${0.1 * (1 - dist / 150)})`;
+                            ctx.strokeStyle = `rgba(${color}, ${0.12 * (1 - dist / 160)})`;
                             ctx.lineWidth = 0.5;
                             ctx.moveTo(p.x, p.y);
                             ctx.lineTo(p2.x, p2.y);
@@ -110,7 +109,7 @@ const ThemeBackground = () => {
         };
     }, [theme]);
 
-    if (theme !== 'quantum' && theme !== 'neon' && theme !== 'living') return null;
+    if (theme !== 'codex' && theme !== 'pastel' && theme !== 'white') return null;
 
     return (
         <canvas
@@ -123,7 +122,7 @@ const ThemeBackground = () => {
                 height: '100vh',
                 zIndex: -1,
                 pointerEvents: 'none',
-                opacity: 0.6
+                opacity: theme === 'white' ? 0.35 : 0.6
             }}
         />
     );

--- a/src/components/Events/EventModal.css
+++ b/src/components/Events/EventModal.css
@@ -17,8 +17,9 @@
 .event-modal {
   width: 100%;
   max-width: 720px;
-  height: min(86vh, 760px);
-  overflow: hidden;
+  height: fit-content;
+  max-height: 86vh;
+  overflow: visible;
   border-radius: 20px;
   padding: 0;
   display: flex;
@@ -118,7 +119,7 @@
   display: flex;
   flex-direction: column;
   flex: 1;
-  overflow: hidden;
+  overflow: visible;
 }
 
 .modal-section {
@@ -155,14 +156,14 @@
 }
 
 .clock-picker {
-  background: rgba(255, 255, 255, 0.7);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.7), rgba(30, 41, 59, 0.7));
   border: 1px solid rgba(148, 163, 184, 0.35);
   border-radius: 16px;
   padding: 0.75rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
-  box-shadow: inset 0 0 20px rgba(148, 163, 184, 0.25);
+  box-shadow: inset 0 0 18px rgba(56, 189, 248, 0.15), 0 12px 30px rgba(15, 23, 42, 0.35);
 }
 
 .clock-picker-header {
@@ -181,7 +182,7 @@
   font-size: 0.95rem;
   font-weight: 700;
   letter-spacing: 0.08em;
-  color: var(--text-primary);
+  color: #e2e8f0;
 }
 
 .clock-face {
@@ -190,12 +191,23 @@
   height: 170px;
   margin: 0 auto;
   border-radius: 50%;
-  background: radial-gradient(circle at center, rgba(255, 255, 255, 0.9), rgba(226, 232, 240, 0.9));
-  border: 1px solid rgba(148, 163, 184, 0.5);
-  box-shadow: inset 0 0 24px rgba(148, 163, 184, 0.25), 0 8px 20px rgba(148, 163, 184, 0.25);
+  background:
+    radial-gradient(circle at center, rgba(30, 41, 59, 0.95), rgba(15, 23, 42, 0.95)),
+    radial-gradient(circle at 20% 20%, rgba(56, 189, 248, 0.25), transparent 55%);
+  border: 1px solid rgba(56, 189, 248, 0.4);
+  box-shadow: inset 0 0 30px rgba(56, 189, 248, 0.2), 0 10px 24px rgba(2, 6, 23, 0.45);
   cursor: crosshair;
   touch-action: none;
   user-select: none;
+}
+
+.clock-face::after {
+  content: '';
+  position: absolute;
+  inset: 10px;
+  border-radius: 50%;
+  border: 1px dashed rgba(56, 189, 248, 0.25);
+  box-shadow: 0 0 12px rgba(56, 189, 248, 0.15);
 }
 
 .clock-mark {
@@ -211,7 +223,7 @@
 
 .clock-mark.major {
   height: 16px;
-  background: rgba(99, 102, 241, 0.55);
+  background: rgba(56, 189, 248, 0.6);
 }
 
 .mark-label {
@@ -221,7 +233,7 @@
   transform: translateX(-50%);
   font-size: 0.6rem;
   font-weight: 700;
-  color: rgba(71, 85, 105, 0.9);
+  color: rgba(226, 232, 240, 0.9);
   user-select: none;
 }
 
@@ -233,7 +245,7 @@
   height: 6px;
   border-radius: 999px;
   transform-origin: center 73px;
-  background: rgba(148, 163, 184, 0.5);
+  background: rgba(148, 163, 184, 0.4);
   user-select: none;
 }
 
@@ -251,16 +263,16 @@
   width: 2px;
   height: 60px;
   margin-top: 25px;
-  background: rgba(59, 130, 246, 0.6);
+  background: rgba(56, 189, 248, 0.8);
   border-radius: 999px;
-  box-shadow: 0 0 8px rgba(59, 130, 246, 0.4);
+  box-shadow: 0 0 12px rgba(56, 189, 248, 0.6);
 }
 
 .clock-hand.minute-hand span {
   height: 70px;
   margin-top: 18px;
-  background: rgba(251, 191, 36, 0.8);
-  box-shadow: 0 0 10px rgba(251, 191, 36, 0.5);
+  background: rgba(248, 113, 113, 0.9);
+  box-shadow: 0 0 14px rgba(248, 113, 113, 0.6);
 }
 
 .clock-hand.active span {
@@ -272,8 +284,8 @@
   width: 10px;
   height: 10px;
   border-radius: 50%;
-  background: #ffffff;
-  box-shadow: 0 0 10px rgba(99, 102, 241, 0.35);
+  background: #e2e8f0;
+  box-shadow: 0 0 12px rgba(56, 189, 248, 0.6);
   top: 50%;
   left: 50%;
   transform: translate(-50%, -50%);
@@ -290,8 +302,8 @@
 
 .clock-action-btn {
   border: 1px solid rgba(148, 163, 184, 0.4);
-  background: rgba(255, 255, 255, 0.7);
-  color: var(--text-secondary);
+  background: rgba(15, 23, 42, 0.6);
+  color: #e2e8f0;
   border-radius: 10px;
   padding: 4px 8px;
   font-size: 0.7rem;
@@ -309,9 +321,9 @@
 }
 
 .clock-action-btn.primary {
-  border-color: rgba(129, 140, 248, 0.7);
-  background: rgba(129, 140, 248, 0.2);
-  color: rgba(67, 56, 202, 0.9);
+  border-color: rgba(56, 189, 248, 0.7);
+  background: rgba(56, 189, 248, 0.2);
+  color: #e2e8f0;
 }
 
 .clock-action-btn:hover:not(:disabled) {

--- a/src/components/Events/EventModal.jsx
+++ b/src/components/Events/EventModal.jsx
@@ -81,6 +81,17 @@ const ClockTimePicker = ({ label, value, onChange }) => {
     }
   };
 
+  const getClosestHand = (degrees) => {
+    const normalize = (angle) => (angle + 360) % 360;
+    const diff = (a, b) => {
+      const delta = Math.abs(normalize(a) - normalize(b));
+      return Math.min(delta, 360 - delta);
+    };
+    const hourDiff = diff(degrees, hourAngle);
+    const minuteDiff = diff(degrees, minuteAngle);
+    return hourDiff <= minuteDiff ? 'hour' : 'minute';
+  };
+
   const startDrag = (event, targetMode) => {
     event.preventDefault();
     event.stopPropagation();
@@ -92,7 +103,15 @@ const ClockTimePicker = ({ label, value, onChange }) => {
   };
 
   const handlePointerDown = (event) => {
-    startDrag(event, modeRef.current);
+    if (!clockRef.current) return;
+    const rect = clockRef.current.getBoundingClientRect();
+    const x = event.clientX - rect.left - rect.width / 2;
+    const y = event.clientY - rect.top - rect.height / 2;
+    const angle = Math.atan2(y, x);
+    const degrees = (angle * 180) / Math.PI;
+    const adjusted = (degrees + 90 + 360) % 360;
+    const closest = getClosestHand(adjusted);
+    startDrag(event, closest);
   };
 
   const handleHandPointerDown = (event, targetMode) => {
@@ -176,7 +195,7 @@ const ClockTimePicker = ({ label, value, onChange }) => {
           Back
         </button>
         <div className="clock-mode-indicator">
-          {mode === 'hour' ? 'Select hour' : 'Select minutes (5m)'}
+          Drag either hand to refine time
         </div>
         <button
           type="button"
@@ -350,7 +369,8 @@ const EventModal = () => {
     { value: 'task', label: 'Task', color: getEventColor('task') },
     { value: 'todo', label: 'To-Do', color: getEventColor('todo') },
     { value: 'event', label: 'Event', color: getEventColor('event') },
-    { value: 'appointment', label: 'Appointment', color: getEventColor('appointment') }
+    { value: 'appointment', label: 'Appointment', color: getEventColor('appointment') },
+    { value: 'holiday', label: 'Holiday', color: getEventColor('holiday') }
   ];
 
   const colorOptions = [
@@ -361,7 +381,8 @@ const EventModal = () => {
     getEventColor('task'),
     getEventColor('todo'),
     getEventColor('event'),
-    getEventColor('appointment')
+    getEventColor('appointment'),
+    getEventColor('holiday')
   ];
 
   const sections = [

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -768,3 +768,96 @@
   background: rgba(255, 255, 255, 0.1);
   border-radius: 10px;
 }
+
+.theme-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.theme-card {
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 16px;
+  padding: 16px;
+  text-align: left;
+  color: #e2e8f0;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  position: relative;
+}
+
+.theme-card:hover {
+  border-color: var(--theme-accent);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.25);
+  transform: translateY(-2px);
+}
+
+.theme-card.active {
+  border-color: var(--theme-accent);
+  box-shadow: 0 0 0 1px var(--theme-accent), 0 10px 24px rgba(15, 23, 42, 0.35);
+}
+
+.theme-card-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+.theme-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 999px;
+  background: var(--theme-accent);
+  box-shadow: 0 0 10px var(--theme-accent);
+}
+
+.theme-card p {
+  margin: 0;
+  font-size: 0.8rem;
+  color: #94a3b8;
+}
+
+.theme-selected {
+  position: absolute;
+  top: 12px;
+  right: 12px;
+  font-size: 0.65rem;
+  font-weight: 700;
+  color: var(--theme-accent);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.general-event-list {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.general-event-item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 14px 16px;
+  border-radius: 14px;
+  background: rgba(15, 23, 42, 0.35);
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+}
+
+.general-event-item h5 {
+  margin: 0;
+  font-size: 0.9rem;
+}
+
+.general-event-item p {
+  margin: 4px 0 0;
+  font-size: 0.75rem;
+  color: #94a3b8;
+}

--- a/src/components/Sidebar/UpcomingSidebar.css
+++ b/src/components/Sidebar/UpcomingSidebar.css
@@ -48,7 +48,7 @@
     border-radius: 10px;
     border: 1px solid rgba(148, 163, 184, 0.2);
     background: rgba(15, 23, 42, 0.4);
-    color: #c7d2fe;
+    color: var(--text-secondary);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -59,14 +59,14 @@
 .icon-btn:hover {
     border-color: rgba(99, 102, 241, 0.45);
     background: rgba(99, 102, 241, 0.15);
-    color: #e0e7ff;
+    color: var(--text-primary);
     transform: translateY(-1px);
 }
 
 .icon-btn.active {
     border-color: rgba(99, 102, 241, 0.6);
     background: rgba(99, 102, 241, 0.25);
-    color: #e0e7ff;
+    color: var(--text-primary);
 }
 
 .icon-btn.active-red {
@@ -102,12 +102,12 @@
 .delete-title {
     font-size: 0.9rem;
     font-weight: 700;
-    color: #f1f5f9;
+    color: var(--text-primary);
 }
 
 .delete-subtitle {
     font-size: 0.75rem;
-    color: #94a3b8;
+    color: var(--text-muted);
 }
 
 .delete-input-wrapper {
@@ -130,16 +130,16 @@
     background: transparent;
     border: none;
     outline: none;
-    color: #e2e8f0;
+    color: var(--text-primary);
     font-size: 0.8rem;
 }
 
 .delete-input::placeholder {
-    color: #64748b;
+    color: var(--text-muted);
 }
 
 .search-icon {
-    color: #94a3b8;
+    color: var(--text-muted);
 }
 
 .close-btn {
@@ -148,7 +148,7 @@
     border-radius: 8px;
     border: 1px solid rgba(148, 163, 184, 0.2);
     background: rgba(148, 163, 184, 0.1);
-    color: #94a3b8;
+    color: var(--text-muted);
     display: inline-flex;
     align-items: center;
     justify-content: center;
@@ -158,7 +158,7 @@
 
 .close-btn:hover {
     border-color: rgba(99, 102, 241, 0.5);
-    color: #e2e8f0;
+    color: var(--text-primary);
 }
 
 .delete-confirm-btn {
@@ -176,7 +176,7 @@
 .delete-confirm-btn:disabled {
     cursor: not-allowed;
     background: rgba(148, 163, 184, 0.2);
-    color: #94a3b8;
+    color: var(--text-muted);
 }
 
 .delete-confirm-btn:not(:disabled):hover {
@@ -187,13 +187,13 @@
 .delete-hint {
     margin: 0;
     font-size: 0.7rem;
-    color: #94a3b8;
+    color: var(--text-muted);
 }
 
 .filter-chip {
     border: 1px solid rgba(148, 163, 184, 0.2);
     background: rgba(15, 23, 42, 0.4);
-    color: #cbd5f5;
+    color: var(--text-secondary);
     padding: 4px 10px;
     font-size: 0.7rem;
     font-weight: 600;
@@ -204,25 +204,25 @@
 
 .filter-chip.active {
     border-color: rgba(99, 102, 241, 0.6);
-    color: #c7d2fe;
+    color: var(--text-primary);
     background: rgba(99, 102, 241, 0.15);
 }
 
 .filter-chip:hover {
     border-color: rgba(99, 102, 241, 0.4);
-    color: #e2e8f0;
+    color: var(--text-primary);
 }
 
 .sidebar-header h3 {
     font-size: 1.25rem;
     font-weight: 700;
     margin: 0;
-    color: #f1f5f9;
+    color: var(--text-primary);
 }
 
 .event-count {
     background: rgba(99, 102, 241, 0.1);
-    color: #818cf8;
+    color: var(--text-secondary);
     padding: 2px 10px;
     border-radius: 12px;
     font-size: 0.8rem;
@@ -256,6 +256,12 @@
     border-color: rgba(255, 255, 255, 0.1);
 }
 
+.upcoming-event-item.past-event {
+    opacity: 0.55;
+    filter: grayscale(0.4);
+    transform: scale(0.98);
+}
+
 .event-date-badge {
     display: flex;
     flex-direction: column;
@@ -272,13 +278,13 @@
     font-size: 0.7rem;
     text-transform: uppercase;
     font-weight: 700;
-    color: #94a3b8;
+    color: var(--text-muted);
 }
 
 .event-date-badge .day {
     font-size: 1.1rem;
     font-weight: 700;
-    color: #f1f5f9;
+    color: var(--text-primary);
 }
 
 .event-info {
@@ -303,7 +309,7 @@
     margin: 0;
     font-size: 0.95rem;
     font-weight: 600;
-    color: #f1f5f9;
+    color: var(--text-primary);
     white-space: nowrap;
     overflow: hidden;
     text-overflow: ellipsis;
@@ -314,7 +320,7 @@
 .time-til {
     font-size: 0.7rem;
     font-weight: 700;
-    color: #818cf8;
+    color: var(--text-secondary);
     background: rgba(99, 102, 241, 0.1);
     padding: 2px 6px;
     border-radius: 6px;
@@ -331,13 +337,13 @@
 .event-info .time {
     margin: 0;
     font-size: 0.8rem;
-    color: #64748b;
+    color: var(--text-muted);
 }
 
 .category-tag {
     font-size: 0.7rem;
     font-weight: 600;
-    color: var(--category-color, #94a3b8);
+    color: var(--category-color, var(--text-muted));
     background: rgba(0, 0, 0, 0.2);
     padding: 1px 6px;
     border-radius: 4px;
@@ -373,7 +379,7 @@
 
 .action-btn.edit {
     background: rgba(99, 102, 241, 0.12);
-    color: #818cf8;
+    color: var(--text-secondary);
 }
 
 .action-btn.delete:hover {
@@ -388,7 +394,7 @@
 
 .action-btn.bulk {
     background: rgba(148, 163, 184, 0.1);
-    color: #94a3b8;
+    color: var(--text-muted);
     width: auto;
     padding: 0 8px;
     gap: 4px;
@@ -407,7 +413,7 @@
     align-items: center;
     justify-content: center;
     flex: 1;
-    color: #475569;
+    color: var(--text-muted);
     gap: 12px;
     text-align: center;
 }

--- a/src/components/Sidebar/UpcomingSidebar.jsx
+++ b/src/components/Sidebar/UpcomingSidebar.jsx
@@ -114,7 +114,8 @@ const UpcomingSidebar = () => {
                         { value: 'task', label: 'Task' },
                         { value: 'todo', label: 'To-Do' },
                         { value: 'event', label: 'Event' },
-                        { value: 'appointment', label: 'Appointment' }
+                        { value: 'appointment', label: 'Appointment' },
+                        { value: 'holiday', label: 'Holiday' }
                     ].map(filter => (
                         <button
                             key={filter.value}
@@ -166,12 +167,14 @@ const UpcomingSidebar = () => {
                         <p>{viewMode === 'upcoming' ? 'No upcoming events' : 'No past events'}</p>
                     </div>
                 ) : (
-                    displayEvents.map(event => (
-                        <div
-                            key={event.id}
-                            className="upcoming-event-item"
-                            style={{ '--category-color': getEventColor(event.category) }}
-                        >
+                    displayEvents.map(event => {
+                        const isPastEvent = new Date(event.end || event.start) < now;
+                        return (
+                            <div
+                                key={event.id}
+                                className={`upcoming-event-item ${isPastEvent ? 'past-event' : ''}`}
+                                style={{ '--category-color': getEventColor(event.category) }}
+                            >
                             <div className="event-date-badge">
                                 <span className="month">
                                     {new Date(event.start).toLocaleString('default', { month: 'short' })}
@@ -212,8 +215,9 @@ const UpcomingSidebar = () => {
                                     <Trash2 size={14} />
                                 </button>
                             </div>
-                        </div>
-                    ))
+                            </div>
+                        );
+                    })
                 )}
             </div>
         </div>

--- a/src/contexts/ThemeContext.jsx
+++ b/src/contexts/ThemeContext.jsx
@@ -1,4 +1,5 @@
-import { createContext, useContext, useState, useEffect } from 'react';
+import { createContext, useContext, useEffect, useRef, useState } from 'react';
+import { firebaseService } from '../services/firebaseService';
 
 const ThemeContext = createContext();
 
@@ -11,29 +12,68 @@ export const useTheme = () => {
 };
 
 export const THEMES = {
-  PRO: 'pro'
+  CODEX: 'codex',
+  PASTEL: 'pastel',
+  WHITE: 'white'
 };
 
 export const ThemeProvider = ({ children }) => {
-  // Always default to PRO, ignore localStorage
-  const [theme] = useState(THEMES.PRO);
+  const [theme, setThemeState] = useState(THEMES.CODEX);
+  const [isDark, setIsDark] = useState(true);
+  const userIdRef = useRef(null);
 
   useEffect(() => {
-    document.documentElement.setAttribute('data-theme', 'pro');
-    document.documentElement.classList.add('dark');
+    const applyTheme = (nextTheme) => {
+      setThemeState(nextTheme);
+      const nextIsDark = nextTheme === THEMES.CODEX;
+      setIsDark(nextIsDark);
+      document.documentElement.setAttribute('data-theme', nextTheme);
+      document.documentElement.classList.toggle('dark', nextIsDark);
+      localStorage.setItem('calai-theme', nextTheme);
+    };
+
+    const loadTheme = async () => {
+      const stored = localStorage.getItem('calai-theme');
+      let nextTheme = stored || THEMES.CODEX;
+
+      if (userIdRef.current) {
+        const userData = await firebaseService.getUserData();
+        if (userData?.theme) {
+          nextTheme = userData.theme;
+        }
+      }
+
+      applyTheme(nextTheme);
+    };
+
+    const unsubscribe = firebaseService.onAuthStateChanged(async (user) => {
+      userIdRef.current = user?.uid ?? null;
+      await loadTheme();
+    });
+
+    loadTheme();
+    return () => unsubscribe?.();
   }, []);
 
-  const toggleTheme = () => {
-    // No-op or toast could go here, but UI button will be removed
-    console.log("Theme is locked to Pro");
+  const setTheme = async (nextTheme) => {
+    if (!Object.values(THEMES).includes(nextTheme)) return;
+    setThemeState(nextTheme);
+    const nextIsDark = nextTheme === THEMES.CODEX;
+    setIsDark(nextIsDark);
+    document.documentElement.setAttribute('data-theme', nextTheme);
+    document.documentElement.classList.toggle('dark', nextIsDark);
+    localStorage.setItem('calai-theme', nextTheme);
+    if (userIdRef.current) {
+      await firebaseService.saveUserData({ theme: nextTheme });
+    }
   };
 
   return (
     <ThemeContext.Provider value={{
       theme,
-      setTheme: () => { }, // No-op
-      toggleTheme,
-      isDark: true
+      setTheme,
+      toggleTheme: () => { },
+      isDark
     }}>
       {children}
     </ThemeContext.Provider>

--- a/src/index.css
+++ b/src/index.css
@@ -1,38 +1,69 @@
-/* Pastel Light Theme */
+/* Base */
 :root {
   font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
   line-height: 1.6;
   font-weight: 400;
-
-  /* Global Colors */
-  --bg-primary: #f7f7ff;
-  /* Soft lavender white */
-  --bg-secondary: #eef2ff;
-  /* Pastel blue */
-  --accent: #a7c5ff;
-  /* Pastel blue */
-  --accent-hover: #bdd3ff;
-  --accent-glow: rgba(167, 197, 255, 0.45);
-
-  /* Text Contrast - Maximize legibility */
-  --text-primary: #1f2937;
-  --text-secondary: #4b5563;
-  --text-muted: #6b7280;
-
-  /* Glass / Surfaces */
-  --glass-bg: rgba(255, 255, 255, 0.75);
-  --glass-border: rgba(148, 163, 184, 0.35);
-  /* Soft pastel border */
-  --glass-shadow: 0 12px 32px rgba(148, 163, 184, 0.25);
-  --backdrop-blur: blur(14px);
-
-  /* Status Colors */
   --success: #10b981;
   --warning: #f59e0b;
   --error: #ef4444;
 }
 
-/* Cleanup: Removed inactive themes (neon, ceo, quantum, zen, living, light) */
+/* Codex Dark (OpenAI-inspired) */
+[data-theme='codex'] {
+  --bg-primary: #0b1120;
+  --bg-secondary: #111827;
+  --bg-tertiary: #1f2937;
+  --accent: #38bdf8;
+  --accent-hover: #7dd3fc;
+  --accent-glow: rgba(56, 189, 248, 0.35);
+  --text-primary: #e2e8f0;
+  --text-secondary: #cbd5f5;
+  --text-muted: #94a3b8;
+  --glass-bg: rgba(15, 23, 42, 0.75);
+  --glass-border: rgba(148, 163, 184, 0.2);
+  --glass-shadow: 0 18px 42px rgba(2, 6, 23, 0.5);
+  --backdrop-blur: blur(18px);
+  --border: rgba(148, 163, 184, 0.2);
+  --shadow: 0 16px 40px rgba(2, 6, 23, 0.45);
+}
+
+/* Vibrant Pastel */
+[data-theme='pastel'] {
+  --bg-primary: #f8f7ff;
+  --bg-secondary: #f1f5ff;
+  --bg-tertiary: #eae9ff;
+  --accent: #a855f7;
+  --accent-hover: #c084fc;
+  --accent-glow: rgba(168, 85, 247, 0.35);
+  --text-primary: #1f2937;
+  --text-secondary: #4b5563;
+  --text-muted: #6b7280;
+  --glass-bg: rgba(255, 255, 255, 0.78);
+  --glass-border: rgba(148, 163, 184, 0.35);
+  --glass-shadow: 0 12px 32px rgba(148, 163, 184, 0.22);
+  --backdrop-blur: blur(14px);
+  --border: rgba(148, 163, 184, 0.3);
+  --shadow: 0 12px 28px rgba(148, 163, 184, 0.2);
+}
+
+/* Crisp White */
+[data-theme='white'] {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f8fafc;
+  --bg-tertiary: #f1f5f9;
+  --accent: #2563eb;
+  --accent-hover: #3b82f6;
+  --accent-glow: rgba(37, 99, 235, 0.25);
+  --text-primary: #0f172a;
+  --text-secondary: #334155;
+  --text-muted: #64748b;
+  --glass-bg: rgba(248, 250, 252, 0.9);
+  --glass-border: rgba(148, 163, 184, 0.3);
+  --glass-shadow: 0 10px 24px rgba(148, 163, 184, 0.2);
+  --backdrop-blur: blur(12px);
+  --border: rgba(148, 163, 184, 0.3);
+  --shadow: 0 10px 24px rgba(148, 163, 184, 0.2);
+}
 
 /* Base Body Style */
 body {
@@ -47,7 +78,6 @@ body {
   overflow-x: hidden;
 }
 
-
 * {
   box-sizing: border-box;
   margin: 0;
@@ -56,18 +86,6 @@ body {
 
 html {
   scroll-behavior: smooth;
-}
-
-body {
-  margin: 0;
-  min-height: 100vh;
-  background: var(--bg-primary);
-  color: var(--text-primary);
-  font-synthesis: none;
-  text-rendering: optimizeLegibility;
-  -webkit-font-smoothing: antialiased;
-  -moz-osx-font-smoothing: grayscale;
-  overflow-x: hidden;
 }
 
 /* Glass morphism base class */

--- a/src/services/aiEventService.js
+++ b/src/services/aiEventService.js
@@ -1,6 +1,7 @@
 import { parseNaturalLanguageDate } from '../utils/dateUtils.js';
 import { applyTimeToDate, extractDurationMinutes, parseTimeRangeToDates, parseTimeToken } from '../utils/timeParser.js';
 import { sanitizeDraft } from '../utils/eventSchema.js';
+import { getEventColor } from '../utils/helpers.js';
 import { AIParseError, AIServiceError } from '../utils/errors.js';
 import { logger } from '../utils/logger.js';
 import { geminiService } from './geminiService.js';
@@ -162,5 +163,6 @@ export const finalizeDraft = (draft) => ({
   description: draft.description || '',
   location: draft.location || '',
   category: draft.category || 'personal',
-  recurring: draft.recurring || { type: 'none' }
+  recurring: draft.recurring || { type: 'none' },
+  color: draft.color || getEventColor(draft.category || 'personal')
 });

--- a/src/services/aiIntentService.js
+++ b/src/services/aiIntentService.js
@@ -24,6 +24,8 @@ const EVENT_QUERY_KEYWORDS = [
   'calendar',
   'schedule',
   'upcoming',
+  'appointment',
+  'next appointment',
   'today',
   'tomorrow',
   'this week',

--- a/src/services/aiQueryService.js
+++ b/src/services/aiQueryService.js
@@ -45,7 +45,7 @@ export const buildQueryResponse = (text, events, now = new Date()) => {
     return `Events for ${dateRange.label}: ${summary}.`;
   }
 
-  if (lower.includes('next') && lower.includes('event')) {
+  if (lower.includes('next') && (lower.includes('event') || lower.includes('appointment'))) {
     const upcoming = sortEventsByStart(getUpcomingEvents(events, now));
     logger.info('AI query: next event', { count: upcoming.length });
     if (upcoming.length === 0) {

--- a/src/services/googleCalendarService.js
+++ b/src/services/googleCalendarService.js
@@ -96,7 +96,9 @@ class GoogleCalendarService {
     }
 
     async listUpcomingEvents() {
-        if (!this.gapiInited) throw new Error("GAPI not initialized");
+        if (!this.gapiInited || !this.isAuthorized) {
+            return [];
+        }
 
         // Ensure token is set for GAPI
         if (this.accessToken) {
@@ -125,7 +127,7 @@ class GoogleCalendarService {
             }));
         } catch (err) {
             console.error("Error listing events", err);
-            throw err;
+            return [];
         }
     }
 

--- a/src/types/calendar.js
+++ b/src/types/calendar.js
@@ -1,5 +1,5 @@
 /**
- * @typedef {'work'|'personal'|'fun'|'hobby'|'task'|'todo'|'event'|'appointment'|'health'|'social'|'travel'|'other'} EventCategory
+ * @typedef {'work'|'personal'|'fun'|'hobby'|'task'|'todo'|'event'|'appointment'|'holiday'|'health'|'social'|'travel'|'other'} EventCategory
  */
 
 /**

--- a/src/utils/dateUtils.js
+++ b/src/utils/dateUtils.js
@@ -107,6 +107,7 @@ export const parseNaturalLanguageDate = (text) => {
   // Simple natural language parsing - can be enhanced
   const now = new Date();
   const lowerText = text.toLowerCase();
+  const weekdays = ['sunday', 'monday', 'tuesday', 'wednesday', 'thursday', 'friday', 'saturday'];
   
   if (lowerText.includes('today')) {
     return new Date();
@@ -122,6 +123,22 @@ export const parseNaturalLanguageDate = (text) => {
   
   if (lowerText.includes('next week')) {
     return addDays(now, 7);
+  }
+
+  const nextWeekdayMatch = lowerText.match(/\bnext\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\b/);
+  if (nextWeekdayMatch) {
+    const targetIndex = weekdays.indexOf(nextWeekdayMatch[1]);
+    const currentIndex = now.getDay();
+    const delta = (7 - currentIndex + targetIndex) % 7 || 7;
+    return addDays(now, delta);
+  }
+
+  const thisWeekdayMatch = lowerText.match(/\bthis\s+(sunday|monday|tuesday|wednesday|thursday|friday|saturday)\b/);
+  if (thisWeekdayMatch) {
+    const targetIndex = weekdays.indexOf(thisWeekdayMatch[1]);
+    const currentIndex = now.getDay();
+    const delta = (7 - currentIndex + targetIndex) % 7;
+    return addDays(now, delta);
   }
   
   // Try to parse standard date formats

--- a/src/utils/eventSchema.js
+++ b/src/utils/eventSchema.js
@@ -7,6 +7,7 @@ export const EVENT_CATEGORIES = [
   'todo',
   'event',
   'appointment',
+  'holiday',
   'health',
   'social',
   'travel',

--- a/src/utils/generalEvents.js
+++ b/src/utils/generalEvents.js
@@ -1,0 +1,57 @@
+import { getEventColor } from './helpers.js';
+
+const buildAllDayEvent = (title, date, packId) => {
+  const start = new Date(date);
+  start.setHours(0, 0, 0, 0);
+  const end = new Date(start);
+  end.setDate(end.getDate() + 1);
+  return {
+    title,
+    start: start.toISOString(),
+    end: end.toISOString(),
+    category: 'holiday',
+    color: getEventColor('holiday'),
+    autoPack: packId,
+    description: '',
+    location: ''
+  };
+};
+
+const getNthWeekdayOfMonth = (year, month, weekday, occurrence) => {
+  const firstDay = new Date(year, month, 1);
+  const firstWeekday = (weekday - firstDay.getDay() + 7) % 7;
+  const day = 1 + firstWeekday + (occurrence - 1) * 7;
+  return new Date(year, month, day);
+};
+
+const getLastWeekdayOfMonth = (year, month, weekday) => {
+  const lastDay = new Date(year, month + 1, 0);
+  const offset = (lastDay.getDay() - weekday + 7) % 7;
+  return new Date(year, month, lastDay.getDate() - offset);
+};
+
+const buildHolidayEventsForYear = (year, packId) => ([
+  buildAllDayEvent("New Year's Day", new Date(year, 0, 1), packId),
+  buildAllDayEvent('Martin Luther King Jr. Day', getNthWeekdayOfMonth(year, 0, 1, 3), packId),
+  buildAllDayEvent('Presidents Day', getNthWeekdayOfMonth(year, 1, 1, 3), packId),
+  buildAllDayEvent('Memorial Day', getLastWeekdayOfMonth(year, 4, 1), packId),
+  buildAllDayEvent('Independence Day', new Date(year, 6, 4), packId),
+  buildAllDayEvent('Labor Day', getNthWeekdayOfMonth(year, 8, 1, 1), packId),
+  buildAllDayEvent('Thanksgiving', getNthWeekdayOfMonth(year, 10, 4, 4), packId),
+  buildAllDayEvent('Christmas Day', new Date(year, 11, 25), packId)
+]);
+
+export const GENERAL_EVENT_PACKS = [
+  {
+    id: 'us-holidays',
+    label: 'US Federal Holidays',
+    description: 'Auto-add major public holidays for this year and next.',
+    buildEvents: (year) => buildHolidayEventsForYear(year, 'us-holidays')
+  }
+];
+
+export const buildGeneralEvents = (packId, years) => {
+  const pack = GENERAL_EVENT_PACKS.find(item => item.id === packId);
+  if (!pack) return [];
+  return years.flatMap(year => pack.buildEvents(year));
+};

--- a/src/utils/helpers.js
+++ b/src/utils/helpers.js
@@ -55,6 +55,7 @@ export const getEventColor = (category) => {
     todo: '#22c55e',
     event: '#ef4444',
     appointment: '#06b6d4',
+    holiday: '#f97316',
     default: '#6b7280'
   };
   

--- a/src/utils/useHourScale.js
+++ b/src/utils/useHourScale.js
@@ -8,7 +8,7 @@ import { useCallback, useLayoutEffect, useState } from 'react';
  *  offset?: number
  * }} options
  */
-export const useHourScale = ({ containerRef, minPixels = 24, maxPixels = 64, offset = 16 }) => {
+export const useHourScale = ({ containerRef, minPixels = 24, maxPixels = 64, offset = 16, fitToViewport = false }) => {
   const [pixelsPerHour, setPixelsPerHour] = useState(36);
 
   const updateScale = useCallback(() => {
@@ -23,9 +23,12 @@ export const useHourScale = ({ containerRef, minPixels = 24, maxPixels = 64, off
       return;
     }
 
-    const next = Math.max(minPixels, Math.min(maxPixels, availableHeight / 24));
+    const rawValue = availableHeight / 24;
+    const next = fitToViewport
+      ? rawValue
+      : Math.max(minPixels, Math.min(maxPixels, rawValue));
     setPixelsPerHour(next);
-  }, [containerRef, minPixels, maxPixels, offset]);
+  }, [containerRef, minPixels, maxPixels, offset, fitToViewport]);
 
   useLayoutEffect(() => {
     updateScale();


### PR DESCRIPTION
### Motivation
- Finish and polish the magnify-on-hover UX for day/week time grids so the 24-hour layout remains visible while giving a focal scale effect. 
- Add image-based event parsing so users can upload screenshots/photos and get draft events to review. 
- Provide per-user theme support and curated general event packs (holidays) to make onboarding and personalization easier. 
- Complete and mark the Settings upgrade checklist to reflect implemented features and UX fixes.

### Description
- Implemented scale-based magnify styling and interaction by adding `--magnify-scale` CSS vars and mouse tracking in `DayView.jsx` and `WeekView.jsx` and corresponding CSS tweaks in `DayView.css` and `WeekView.css`. 
- Added image upload UI and review/confirm flows in `AIChat.jsx` with `geminiService.parseEventsFromImages` and file-to-part helpers in `geminiService.js`, plus draft sanitization via `finalizeDraft` in `aiEventService.js`. 
- Introduced theme selection and persistence with `ThemeContext.jsx`, theme visuals in `index.css` and `ThemeBackground.jsx`, and an `appearance` tab in `Settings.jsx` including three themes and general event packs wired to `GENERAL_EVENT_PACKS`/`generalEvents.js`. 
- Miscellaneous improvements: expanded event categories to include `holiday` (`types/calendar.js`, `eventSchema.js`), set default event colors (`aiEventService.js` + `helpers.js`), improved local model JSON repair (`localBrainService.js`), refined AI query intent for “next appointment” (`aiIntentService.js`/`aiQueryService.js`), and made event add/update/delete paths accept `silent`/`skip` options in `EventsContext.jsx` for bulk/pack operations.

### Testing
- Ran `npm run dev -- --host 0.0.0.0 --port 4173` which started Vite successfully and served the app (success).
- Executed a Playwright screenshot script against the running app which produced an artifact (`artifacts/cal-login-updated.png`) for visual verification (success).
- Ran `npm run lint` which surfaced pre-existing lint issues unrelated to these changes; lint failed with 43 problems (40 errors, 3 warnings) so linting did not fully pass (failure).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69701c2de7e0832eba81ed0baba9f7d8)