### PR TITLE
Revamp calendar header and event layouts

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -1,12 +1,14 @@
 .app {
   min-height: 100vh;
   width: 100%;
+  overflow: hidden;
 }
 
 .app-container {
   min-height: 100vh;
   display: flex;
   flex-direction: column;
+  overflow: hidden;
 }
 
 .main-content {
@@ -18,7 +20,7 @@
   display: grid;
   grid-template-columns: 320px 1fr;
   gap: 1.5rem;
-  height: calc(100vh - 118px);
+  min-height: 0;
   overflow: hidden;
 }
 

--- a/src/components/Calendar/MonthView.css
+++ b/src/components/Calendar/MonthView.css
@@ -94,8 +94,41 @@
 .day-number {
   font-size: 0.9rem;
   font-weight: 600;
-  margin-bottom: 0.35rem;
+  margin-bottom: 0;
   color: var(--text-primary);
+}
+
+.day-heading {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 0.35rem;
+  gap: 0.5rem;
+}
+
+.day-add-btn {
+  border: 1px solid rgba(92, 200, 255, 0.35);
+  background: rgba(15, 23, 42, 0.5);
+  color: var(--text-primary);
+  border-radius: 8px;
+  padding: 0.2rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  opacity: 0;
+  transform: translateY(-2px);
+  transition: all 0.2s ease;
+}
+
+.month-day:hover .day-add-btn,
+.month-day:focus-within .day-add-btn {
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.day-add-btn:hover {
+  background: rgba(92, 200, 255, 0.2);
+  border-color: rgba(92, 200, 255, 0.6);
 }
 
 .day-events {
@@ -177,6 +210,11 @@
 
   .day-number {
     font-size: 0.8rem;
+  }
+
+  .day-add-btn {
+    opacity: 1;
+    transform: none;
   }
 
   .day-event {

--- a/src/components/Calendar/MonthView.jsx
+++ b/src/components/Calendar/MonthView.jsx
@@ -1,4 +1,5 @@
 import { motion } from 'framer-motion';
+import { Plus } from 'lucide-react';
 import { getMonthDays, isSameMonth, isToday, formatTime24 } from '../../utils/dateUtils';
 import { useCalendar, CALENDAR_VIEWS } from '../../contexts/CalendarContext';
 import { useEvents } from '../../contexts/EventsContext';
@@ -27,6 +28,14 @@ const MonthView = () => {
   };
 
   const handleDayDoubleClick = (day) => {
+    openEventModal({
+      start: new Date(day.getFullYear(), day.getMonth(), day.getDate(), 9, 0),
+      end: new Date(day.getFullYear(), day.getMonth(), day.getDate(), 10, 0)
+    });
+  };
+
+  const handleAddEventClick = (day, e) => {
+    e.stopPropagation();
     openEventModal({
       start: new Date(day.getFullYear(), day.getMonth(), day.getDate(), 9, 0),
       end: new Date(day.getFullYear(), day.getMonth(), day.getDate(), 10, 0)
@@ -75,8 +84,18 @@ const MonthView = () => {
                 dayEvents.length > 0 && 'has-events'
               )}
             >
-              <div className="day-number">
-                {day.getDate()}
+              <div className="day-heading">
+                <div className="day-number">
+                  {day.getDate()}
+                </div>
+                <button
+                  type="button"
+                  className="day-add-btn"
+                  onClick={(event) => handleAddEventClick(day, event)}
+                  aria-label={`Add event on ${day.toDateString()}`}
+                >
+                  <Plus size={14} />
+                </button>
               </div>
 
               <div className="day-events">

--- a/src/components/Calendar/WeekView.css
+++ b/src/components/Calendar/WeekView.css
@@ -212,6 +212,15 @@
   opacity: 0.8;
 }
 
+.week-event-location {
+  font-size: 0.62rem;
+  opacity: 0.8;
+  margin-top: 0.2rem;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .week-current-time {
   position: absolute;
   left: 70px;

--- a/src/components/Calendar/WeekView.jsx
+++ b/src/components/Calendar/WeekView.jsx
@@ -137,6 +137,7 @@ const WeekView = () => {
                     const isPastEvent = new Date(event.end || event.start) < now;
                     const width = `${100 / columns}%`;
                     const left = `calc(${column * (100 / columns)}% + 2px)`;
+                    const showLocation = height > 42;
                     return (
                       <motion.div
                         key={event.id}
@@ -153,12 +154,13 @@ const WeekView = () => {
                         animate={{ opacity: 1, scale: 1 }}
                         transition={{ delay: index * 0.05 }}
                       >
-                        <div className="week-event-title">{event.title}</div>
-                        {height > 24 && (
-                          <div className="week-event-time">
-                            {formatTime24(new Date(event.start))} - {formatTime24(new Date(event.end))}
-                            <span className="week-event-duration">· {formatDuration(event.start, event.end)}</span>
-                          </div>
+                        <div className="week-event-title">{event.title || 'Untitled'}</div>
+                        <div className="week-event-time">
+                          {formatTime24(new Date(event.start))} - {formatTime24(new Date(event.end))}
+                          <span className="week-event-duration">· {formatDuration(event.start, event.end)}</span>
+                        </div>
+                        {showLocation && event.location && (
+                          <div className="week-event-location">{event.location}</div>
                         )}
                       </motion.div>
                     );

--- a/src/components/Calendar/YearView.jsx
+++ b/src/components/Calendar/YearView.jsx
@@ -119,7 +119,7 @@ const YearView = () => {
                       count > 0 && 'has-events',
                       mode === 'frequency' && intensity > 0 && `level-${intensity}`
                     )}
-                    title={`${format(day, 'MMM d')} · ${count} event${count === 1 ? '' : 's'}`}
+                    title={`${format(day, 'MMM d')} · ${count} ${count === 1 ? 'event' : 'events'}`}
                     style={dayStyle}
                     onClick={() => {
                       const selectedDay = new Date(day);

--- a/src/components/Events/EventModal.css
+++ b/src/components/Events/EventModal.css
@@ -16,7 +16,7 @@
 
 .event-modal {
   width: 100%;
-  max-width: 1100px;
+  max-width: 960px;
   height: fit-content;
   max-height: 86vh;
   overflow: visible;
@@ -91,7 +91,7 @@
 
 .modal-panels {
   display: grid;
-  grid-template-columns: repeat(3, minmax(0, 1fr));
+  grid-template-columns: 1fr;
   gap: 1rem;
 }
 
@@ -115,7 +115,7 @@
 }
 
 .form-group {
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 .form-group label {
@@ -138,7 +138,7 @@
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
-  margin-bottom: 0.75rem;
+  margin-bottom: 0.5rem;
 }
 
 .clock-picker {

--- a/src/components/Events/EventModal.jsx
+++ b/src/components/Events/EventModal.jsx
@@ -471,7 +471,7 @@ const EventModal = () => {
               </div>
 
               <div className="modal-section" aria-label="Schedule details">
-                <h4 className="panel-title"><Clock size={14} /> Schedule details</h4>
+                <h4 className="panel-title"><Clock size={14} /> Schedule time</h4>
                 <div className="form-row">
                   <div className="form-group">
                     <label htmlFor="start-date">
@@ -531,8 +531,8 @@ const EventModal = () => {
                 </div>
               </div>
 
-              <div className="modal-section" aria-label="Event preferences">
-                <h4 className="panel-title"><Palette size={14} /> Preferences</h4>
+              <div className="modal-section" aria-label="Event type">
+                <h4 className="panel-title"><Palette size={14} /> Type & preferences</h4>
                 <div className="form-row">
                   <div className="form-group">
                     <label htmlFor="category">Category</label>

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -27,6 +27,7 @@
   align-items: center;
   gap: 0.75rem;
   flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .quick-event-form {
@@ -126,9 +127,9 @@
 }
 
 .header-content {
-  display: flex;
+  display: grid;
+  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr) minmax(320px, 420px);
   align-items: center;
-  justify-content: space-between;
   gap: 1.5rem;
 }
 
@@ -187,56 +188,119 @@
   margin: 0;
 }
 
-.header-subtitle {
-  font-size: 0.85rem;
-  color: var(--text-muted);
-}
-
 .header-right {
   flex: 0 0 auto;
   display: flex;
-  align-items: center;
-  gap: 1rem;
+  flex-direction: column;
+  align-items: flex-end;
+  gap: 0.75rem;
 }
 
-.view-switcher {
+.view-dropdown {
+  position: relative;
+  min-width: 240px;
+}
+
+.view-dropdown-trigger {
+  width: 100%;
+  border-radius: 16px;
+  padding: 0.55rem 0.75rem;
   display: flex;
-  border-radius: 12px;
-  padding: 0.2rem;
-  overflow: hidden;
-  gap: 0.2rem;
-  flex-wrap: wrap;
-}
-
-.view-btn {
-  padding: 0.35rem 0.75rem;
-  border: none;
-  background: rgba(12, 18, 34, 0.7);
-  color: var(--text-secondary);
-  font-size: 0.875rem;
-  font-weight: 500;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  border: 1px solid rgba(92, 200, 255, 0.3);
+  background: rgba(12, 18, 34, 0.8);
+  color: var(--text-primary);
   cursor: pointer;
-  border-radius: 10px;
   transition: all 0.2s ease;
-  display: flex;
-  align-items: center;
-  min-width: 170px;
 }
 
-.view-btn:hover {
+.view-dropdown-trigger:hover {
+  border-color: rgba(92, 200, 255, 0.6);
+  box-shadow: 0 0 18px rgba(92, 200, 255, 0.15);
+}
+
+.view-dropdown-trigger svg {
+  transition: transform 0.2s ease;
+}
+
+.view-dropdown-label {
+  display: flex;
+  flex-direction: column;
+  text-align: left;
+}
+
+.view-dropdown-title {
+  font-size: 0.9rem;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.view-dropdown-subtitle {
+  font-size: 0.72rem;
+  color: var(--text-muted);
+  letter-spacing: 0.02em;
+}
+
+.view-dropdown-menu {
+  position: absolute;
+  top: calc(100% + 0.5rem);
+  right: 0;
+  width: 100%;
+  padding: 0.5rem;
+  border-radius: 14px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  z-index: 20;
+}
+
+.view-dropdown-option {
+  border: none;
+  background: transparent;
+  color: var(--text-secondary);
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+  padding: 0.6rem 0.75rem;
+  border-radius: 12px;
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.view-dropdown-option .option-title {
+  font-size: 0.85rem;
+  font-weight: 600;
+}
+
+.view-dropdown-option .option-subtitle {
+  font-size: 0.7rem;
+  color: var(--text-muted);
+}
+
+.view-dropdown-option:hover {
   background: rgba(92, 200, 255, 0.12);
   color: var(--text-primary);
 }
 
-.view-btn.active {
-  background: var(--accent);
-  color: white;
+.view-dropdown-option.active {
+  background: rgba(92, 200, 255, 0.2);
+  color: var(--text-primary);
+  border: 1px solid rgba(92, 200, 255, 0.4);
+}
+
+.view-dropdown-trigger svg.rotate {
+  transform: rotate(180deg);
 }
 
 .action-buttons {
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .ai-btn.logo-btn {
@@ -271,13 +335,14 @@
 /* Mobile Responsive */
 @media (max-width: 768px) {
   .header-content {
-    flex-direction: column;
+    grid-template-columns: 1fr;
     gap: 1rem;
   }
 
   .header-left,
   .header-right {
-    flex: none;
+    width: 100%;
+    align-items: center;
   }
 
   .header-center {
@@ -298,16 +363,12 @@
     width: 100%;
   }
 
-  .view-switcher {
+  .view-dropdown {
     width: 100%;
-    justify-content: center;
   }
 
-  .view-btn {
-    flex: 1;
-    text-align: center;
-    min-width: 0;
-    align-items: center;
+  .view-dropdown-trigger {
+    width: 100%;
   }
 
   .action-buttons {
@@ -335,10 +396,5 @@
 
   .header-title {
     font-size: 1.125rem;
-  }
-
-  .view-btn {
-    padding: 0.375rem 0.75rem;
-    font-size: 0.8rem;
   }
 }

--- a/src/index.css
+++ b/src/index.css
@@ -45,7 +45,7 @@ body {
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
-  overflow-x: hidden;
+  overflow: hidden;
 }
 
 * {


### PR DESCRIPTION
### Motivation
- Remove redundant/overflowing header content and make the top bar more compact and professional so everything (settings, quick input, view selector) fits without page scroll. 
- Allow adding events directly from `Month` view and make event cards show useful details on any view. 
- Simplify the add/edit event modal so title/description and schedule are ordered clearly and the UI is less cluttered.

### Description
- Reworked the header into a compact grid and replaced the old inline buttons with a fancy dropdown view selector (`src/components/Header/Header.jsx` + `src/components/Header/Header.css`), keeping AI, search and settings buttons visible and restoring layout stability. 
- Removed the duplicated subtitle in the header and now use `getHeaderTitle()` / `formatFullDate()` appropriately so the header no longer prints the date twice. 
- Added inline quick-add controls to `Month` view by introducing a `Plus` button per day and `handleAddEventClick()` to open the event modal from `src/components/Calendar/MonthView.jsx` and updated styling in `src/components/Calendar/MonthView.css`. 
- Reordered and condensed the event modal into a single-column flow with `Title`/`Description` at the top, schedule/time picker in the middle, and `Type & preferences` last; reduced modal width and spacing for a cleaner look (`src/components/Events/EventModal.jsx`, `src/components/Events/EventModal.css`). 
- Week view event cards now always render title and time and optionally show `location` when there is enough vertical space, and relevant CSS was added to display the extra detail (`src/components/Calendar/WeekView.jsx`, `src/components/Calendar/WeekView.css`). 
- Fixed pluralization in year tooltip strings (`src/components/Calendar/YearView.jsx`). 
- Removed the small unwanted page scroll by tightening overflow and sizing on layout elements (`src/App.css`, `src/index.css`).

### Testing
- Started the dev server with `npm run dev` and the Vite server reported ready on the local and network URLs, indicating the app boots successfully. (Succeeded.)
- Captured a full-page screenshot via a Playwright script pointing at the running dev site and saved `artifacts/calendar-ui.png` to validate the UI changes render as expected. (Succeeded.)
- No unit/integration test suite was executed as part of this PR (UI/CSS changes only).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69752660b5a8832ea967c40c95b1b919)