### PR TITLE
Optimized Event Modals and Forms with Fit, Population, and Image Enhancements

### DIFF
--- a/src/components/forms/EventForm.css
+++ b/src/components/forms/EventForm.css
@@ -1,0 +1,130 @@
+.event-form {
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+  color: #e5e7eb;
+}
+
+.event-form-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.event-form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  font-size: 0.9rem;
+}
+
+.event-form-field input,
+.event-form-field select,
+.event-form-field textarea {
+  background: rgba(15, 23, 42, 0.6);
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  border-radius: 0.75rem;
+  padding: 0.65rem 0.85rem;
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.event-form-error {
+  color: #fca5a5;
+  font-size: 0.8rem;
+}
+
+.event-form-warning {
+  color: #fbbf24;
+  font-size: 0.85rem;
+  margin: 0;
+}
+
+.event-form-accordion {
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  border-radius: 1rem;
+  overflow: hidden;
+  background: rgba(15, 23, 42, 0.4);
+}
+
+.accordion-toggle {
+  width: 100%;
+  text-align: left;
+  padding: 0.85rem 1rem;
+  font-size: 0.95rem;
+  background: transparent;
+  border: none;
+  color: inherit;
+  cursor: pointer;
+}
+
+.accordion-content {
+  display: none;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 0 1rem 1rem;
+}
+
+.accordion-content.open {
+  display: flex;
+}
+
+.event-form-image-preview {
+  display: grid;
+  grid-template-columns: minmax(0, 160px) 1fr;
+  gap: 1rem;
+  align-items: start;
+}
+
+.event-form-image-preview img {
+  width: 100%;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  object-fit: cover;
+}
+
+.event-form-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  font-size: 0.8rem;
+  color: rgba(226, 232, 240, 0.7);
+}
+
+.event-form-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+}
+
+.event-form-actions button,
+.event-form-image-preview button {
+  border-radius: 999px;
+  border: none;
+  padding: 0.6rem 1.2rem;
+  font-weight: 600;
+  background: #6366f1;
+  color: #fff;
+  cursor: pointer;
+}
+
+.event-form-actions button.secondary,
+.event-form-image-preview button.secondary {
+  background: rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+}
+
+.event-form-actions button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+@media (max-width: 720px) {
+  .event-form-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .event-form-image-preview {
+    grid-template-columns: 1fr;
+  }
+}

--- a/src/components/forms/EventForm.tsx
+++ b/src/components/forms/EventForm.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useMemo, useState, type ChangeEvent } from 'react';
+import { addHours, format, parse, parseISO } from 'date-fns';
+import { analyzeImage, validateEventForm, type EventFormValues } from '../../utils/formValidators';
+import { useEventForm } from './useEventForm';
+import './EventForm.css';
+
+export type EventDataInput = Partial<EventFormValues> & {
+  start?: string | Date;
+  end?: string | Date;
+};
+
+export type EventFormProps = {
+  eventData?: EventDataInput;
+  mode: 'create' | 'edit';
+  onSubmit: (data: EventFormValues) => void;
+  onCancel?: () => void;
+};
+
+const DATE_INPUT_FORMAT = "yyyy-MM-dd'T'HH:mm";
+
+const DEFAULT_EVENT_TYPES = ['Meeting', 'Reminder', 'Focus', 'Travel'];
+
+const parseDateInput = (value: string) => parse(value, DATE_INPUT_FORMAT, new Date());
+
+const normalizeDateValue = (value?: string | Date) => {
+  if (!value) return new Date();
+  if (value instanceof Date) return value;
+  const parsed = parseISO(value);
+  return Number.isNaN(parsed.getTime()) ? new Date() : parsed;
+};
+
+const buildInitialValues = (eventData?: EventDataInput): EventFormValues => {
+  const start = normalizeDateValue(eventData?.start);
+  const end = normalizeDateValue(eventData?.end ?? addHours(start, 1));
+
+  return {
+    title: eventData?.title ?? '',
+    description: eventData?.description ?? '',
+    start,
+    end,
+    type: eventData?.type ?? DEFAULT_EVENT_TYPES[0],
+    location: eventData?.location ?? '',
+    imageUrl: eventData?.imageUrl ?? '',
+    imageAlt: eventData?.imageAlt ?? '',
+    imageMeta: eventData?.imageMeta ?? null,
+  };
+};
+
+const EventForm = ({ eventData, mode, onSubmit, onCancel }: EventFormProps) => {
+  const initialValues = useMemo(() => buildInitialValues(eventData), [eventData]);
+  const { values, errors, setFieldValue, resetForm, handleSubmit, hasChanges } = useEventForm({
+    initialValues,
+    onSubmit,
+    validate: validateEventForm,
+  });
+  const [imageStatus, setImageStatus] = useState<'idle' | 'loading' | 'ready' | 'error'>('idle');
+  const [imageError, setImageError] = useState('');
+  const [showDetails, setShowDetails] = useState(true);
+  const [showImagePanel, setShowImagePanel] = useState(false);
+
+  useEffect(() => {
+    if (mode === 'edit' && eventData) {
+      resetForm(buildInitialValues(eventData));
+    }
+  }, [eventData, mode, resetForm]);
+
+  const onChangeDate = (key: 'start' | 'end') => (event: ChangeEvent<HTMLInputElement>) => {
+    const nextDate = parseDateInput(event.target.value);
+    setFieldValue(key, nextDate);
+    if (key === 'start' && nextDate > values.end) {
+      setFieldValue('end', addHours(nextDate, 1));
+    }
+  };
+
+  const onImageChange = async (event: ChangeEvent<HTMLInputElement>) => {
+    const file = event.target.files?.[0];
+    if (!file) return;
+
+    setImageStatus('loading');
+    setImageError('');
+
+    try {
+      const result = await analyzeImage(file);
+      if (result.error) {
+        setImageStatus('error');
+        setImageError(result.error);
+        setFieldValue('imageMeta', result.metadata ?? null);
+        return;
+      }
+
+      setFieldValue('imageUrl', result.dataUrl);
+      setFieldValue('imageAlt', result.altText);
+      setFieldValue('imageMeta', result.metadata ?? null);
+      setImageStatus('ready');
+    } catch (error) {
+      setImageStatus('error');
+      setImageError(error instanceof Error ? error.message : 'Image analysis failed.');
+    }
+  };
+
+  const onResetImage = () => {
+    setFieldValue('imageUrl', '');
+    setFieldValue('imageAlt', '');
+    setFieldValue('imageMeta', null);
+    setImageStatus('idle');
+    setImageError('');
+  };
+
+  return (
+    <form className="event-form" onSubmit={handleSubmit}>
+      <div className="event-form-grid">
+        <label className="event-form-field">
+          <span>Title</span>
+          <input
+            type="text"
+            value={values.title}
+            onChange={(event) => setFieldValue('title', event.target.value)}
+            aria-invalid={Boolean(errors.title)}
+            aria-describedby={errors.title ? 'event-title-error' : undefined}
+            placeholder="Event title"
+          />
+          {errors.title && (
+            <span id="event-title-error" className="event-form-error">
+              {errors.title}
+            </span>
+          )}
+        </label>
+
+        <label className="event-form-field">
+          <span>Type</span>
+          <select value={values.type} onChange={(event) => setFieldValue('type', event.target.value)}>
+            {DEFAULT_EVENT_TYPES.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+        </label>
+
+        <label className="event-form-field">
+          <span>Start</span>
+          <input
+            type="datetime-local"
+            value={format(values.start, DATE_INPUT_FORMAT)}
+            onChange={onChangeDate('start')}
+            aria-invalid={Boolean(errors.start)}
+          />
+          {errors.start && <span className="event-form-error">{errors.start}</span>}
+        </label>
+
+        <label className="event-form-field">
+          <span>End</span>
+          <input
+            type="datetime-local"
+            value={format(values.end, DATE_INPUT_FORMAT)}
+            onChange={onChangeDate('end')}
+            aria-invalid={Boolean(errors.end)}
+          />
+          {errors.end && <span className="event-form-error">{errors.end}</span>}
+        </label>
+      </div>
+
+      <div className="event-form-accordion">
+        <button
+          type="button"
+          className="accordion-toggle"
+          onClick={() => setShowDetails((prev) => !prev)}
+          aria-expanded={showDetails}
+        >
+          Optional details
+        </button>
+        <div className={`accordion-content ${showDetails ? 'open' : ''}`}>
+          <label className="event-form-field">
+            <span>Description</span>
+            <textarea
+              rows={3}
+              value={values.description}
+              onChange={(event) => setFieldValue('description', event.target.value)}
+              placeholder="Add a short agenda or notes"
+            />
+          </label>
+          <label className="event-form-field">
+            <span>Location</span>
+            <input
+              type="text"
+              value={values.location}
+              onChange={(event) => setFieldValue('location', event.target.value)}
+              placeholder="Conference room, Zoom link, etc."
+            />
+          </label>
+        </div>
+      </div>
+
+      <div className="event-form-accordion">
+        <button
+          type="button"
+          className="accordion-toggle"
+          onClick={() => setShowImagePanel((prev) => !prev)}
+          aria-expanded={showImagePanel}
+        >
+          Image & metadata
+        </button>
+        <div className={`accordion-content ${showImagePanel ? 'open' : ''}`}>
+          <div className="event-form-field">
+            <span>Upload image</span>
+            <input type="file" accept="image/*" onChange={onImageChange} />
+            {imageError && <span className="event-form-error">{imageError}</span>}
+            {errors.imageUrl && <span className="event-form-error">{errors.imageUrl}</span>}
+          </div>
+
+          {values.imageUrl && (
+            <div className="event-form-image-preview">
+              <img src={values.imageUrl} alt={values.imageAlt || 'Event'} />
+              <div>
+                <label className="event-form-field">
+                  <span>Alt text</span>
+                  <input
+                    type="text"
+                    value={values.imageAlt}
+                    onChange={(event) => setFieldValue('imageAlt', event.target.value)}
+                    placeholder="Describe the image"
+                  />
+                </label>
+                <div className="event-form-meta">
+                  <span>Status: {imageStatus}</span>
+                  {values.imageMeta && (
+                    <span>
+                      {values.imageMeta.width ?? '—'}x{values.imageMeta.height ?? '—'} ·{' '}
+                      {values.imageMeta.type ?? 'unknown'} ·{' '}
+                      {values.imageMeta.size ? `${Math.round(values.imageMeta.size / 1024)}KB` : '—'}
+                    </span>
+                  )}
+                </div>
+                <button type="button" className="secondary" onClick={onResetImage}>
+                  Remove image
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+
+      {mode === 'edit' && !hasChanges && (
+        <p className="event-form-warning">No changes detected. Update a field to enable save.</p>
+      )}
+
+      <div className="event-form-actions">
+        {onCancel && (
+          <button type="button" className="secondary" onClick={onCancel}>
+            Cancel
+          </button>
+        )}
+        <button type="submit" disabled={mode === 'edit' && !hasChanges}>
+          {mode === 'edit' ? 'Save changes' : 'Create event'}
+        </button>
+      </div>
+    </form>
+  );
+};
+
+export default EventForm;

--- a/src/components/forms/useEventForm.ts
+++ b/src/components/forms/useEventForm.ts
@@ -1,0 +1,52 @@
+import { useCallback, useMemo, useRef, useState, type FormEvent } from 'react';
+import { normalizeEventValues, type EventFormErrors, type EventFormValues } from '../../utils/formValidators';
+
+const serialize = (values: EventFormValues) => JSON.stringify(normalizeEventValues(values));
+
+type UseEventFormOptions = {
+  initialValues: EventFormValues;
+  onSubmit: (values: EventFormValues) => void;
+  validate: (values: EventFormValues) => EventFormErrors;
+};
+
+export const useEventForm = ({ initialValues, onSubmit, validate }: UseEventFormOptions) => {
+  const [values, setValues] = useState<EventFormValues>(initialValues);
+  const [errors, setErrors] = useState<EventFormErrors>({});
+  const baselineRef = useRef<string>(serialize(initialValues));
+
+  const setFieldValue = useCallback(<K extends keyof EventFormValues>(key: K, value: EventFormValues[K]) => {
+    setValues((prev) => ({
+      ...prev,
+      [key]: value,
+    }));
+  }, []);
+
+  const resetForm = useCallback((nextValues: EventFormValues) => {
+    setValues(nextValues);
+    setErrors({});
+    baselineRef.current = serialize(nextValues);
+  }, []);
+
+  const handleSubmit = useCallback(
+    (event?: FormEvent<HTMLFormElement>) => {
+      event?.preventDefault();
+      const validationErrors = validate(values);
+      setErrors(validationErrors);
+      if (Object.keys(validationErrors).length === 0) {
+        onSubmit(values);
+      }
+    },
+    [onSubmit, validate, values],
+  );
+
+  const hasChanges = useMemo(() => serialize(values) !== baselineRef.current, [values]);
+
+  return {
+    values,
+    errors,
+    setFieldValue,
+    resetForm,
+    handleSubmit,
+    hasChanges,
+  };
+};

--- a/src/components/modals/CreateEventModal.tsx
+++ b/src/components/modals/CreateEventModal.tsx
@@ -1,0 +1,38 @@
+import EventModalShell from './EventModalShell';
+import type { EventDataInput } from '../forms/EventForm';
+import type { EventFormValues } from '../../utils/formValidators';
+import type { EventListItem } from './EventCollectionsPanel';
+
+export type CreateEventModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: EventFormValues) => void;
+  seedData?: EventDataInput;
+  upcomingEvents?: EventListItem[];
+  archivedEvents?: EventListItem[];
+  onDeleteEvents?: (events: EventListItem[]) => void;
+};
+
+const CreateEventModal = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  seedData,
+  upcomingEvents,
+  archivedEvents,
+  onDeleteEvents,
+}: CreateEventModalProps) => (
+  <EventModalShell
+    isOpen={isOpen}
+    title="Create event"
+    mode="create"
+    eventData={seedData}
+    onClose={onClose}
+    onSubmit={onSubmit}
+    upcomingEvents={upcomingEvents}
+    archivedEvents={archivedEvents}
+    onDeleteEvents={onDeleteEvents}
+  />
+);
+
+export default CreateEventModal;

--- a/src/components/modals/EditEventModal.tsx
+++ b/src/components/modals/EditEventModal.tsx
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+import EventModalShell from './EventModalShell';
+import type { EventDataInput } from '../forms/EventForm';
+import type { EventFormValues } from '../../utils/formValidators';
+import type { EventListItem } from './EventCollectionsPanel';
+
+export type EditEventModalProps = {
+  isOpen: boolean;
+  onClose: () => void;
+  onSubmit: (data: EventFormValues) => void;
+  eventData: EventDataInput;
+  upcomingEvents?: EventListItem[];
+  archivedEvents?: EventListItem[];
+  onDeleteEvents?: (events: EventListItem[]) => void;
+};
+
+const EditEventModal = ({
+  isOpen,
+  onClose,
+  onSubmit,
+  eventData,
+  upcomingEvents,
+  archivedEvents,
+  onDeleteEvents,
+}: EditEventModalProps) => {
+  const [activeEvent, setActiveEvent] = useState<EventDataInput>(eventData);
+
+  useEffect(() => {
+    if (isOpen) {
+      setActiveEvent(eventData);
+    }
+  }, [eventData, isOpen]);
+
+  return (
+    <EventModalShell
+      isOpen={isOpen}
+      title="Edit event"
+      mode="edit"
+      eventData={activeEvent}
+      onClose={onClose}
+      onSubmit={onSubmit}
+      upcomingEvents={upcomingEvents}
+      archivedEvents={archivedEvents}
+      onDeleteEvents={onDeleteEvents}
+    />
+  );
+};
+
+export default EditEventModal;

--- a/src/components/modals/EventCollectionsPanel.tsx
+++ b/src/components/modals/EventCollectionsPanel.tsx
@@ -1,0 +1,161 @@
+import { useMemo, useState } from 'react';
+import type { EventFormValues } from '../../utils/formValidators';
+import './EventModals.css';
+
+export type EventListItem = EventFormValues & { id?: string };
+
+type EventCollectionsPanelProps = {
+  upcomingEvents?: EventListItem[];
+  archivedEvents?: EventListItem[];
+  onDeleteEvents?: (events: EventListItem[]) => void;
+};
+
+const BulkDeleteIcon = () => (
+  <svg width="16" height="16" viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+    <path
+      d="M4 7h6l1 12H5L4 7zm9 0h6l-1 12h-6l1-12zM9 7V5a2 2 0 0 1 2-2h2a2 2 0 0 1 2 2v2"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      fill="none"
+    />
+  </svg>
+);
+
+const getTypeOptions = (events: EventListItem[]) => {
+  const types = new Set<string>();
+  events.forEach((event) => types.add(event.type));
+  return ['All Types', ...Array.from(types).sort()];
+};
+
+const filterByType = (events: EventListItem[], selectedType: string) => {
+  if (selectedType === 'All Types') return events;
+  return events.filter((event) => event.type === selectedType);
+};
+
+const EventCollectionsPanel = ({ upcomingEvents = [], archivedEvents = [], onDeleteEvents }: EventCollectionsPanelProps) => {
+  const [upcomingType, setUpcomingType] = useState('All Types');
+  const [archivedType, setArchivedType] = useState('All Types');
+  const [selectedUpcoming, setSelectedUpcoming] = useState<Set<string>>(new Set());
+  const [selectedArchived, setSelectedArchived] = useState<Set<string>>(new Set());
+
+  const upcomingOptions = useMemo(() => getTypeOptions(upcomingEvents), [upcomingEvents]);
+  const archivedOptions = useMemo(() => getTypeOptions(archivedEvents), [archivedEvents]);
+
+  const filteredUpcoming = useMemo(
+    () => filterByType(upcomingEvents, upcomingType),
+    [upcomingEvents, upcomingType],
+  );
+  const filteredArchived = useMemo(
+    () => filterByType(archivedEvents, archivedType),
+    [archivedEvents, archivedType],
+  );
+
+  const toggleSelection = (set: Set<string>, key: string, update: (next: Set<string>) => void) => {
+    const next = new Set(set);
+    if (next.has(key)) {
+      next.delete(key);
+    } else {
+      next.add(key);
+    }
+    update(next);
+  };
+
+  const handleBulkDelete = (events: EventListItem[], selected: Set<string>, reset: () => void) => {
+    if (!onDeleteEvents) return;
+    const selectedEvents = events.filter((event, index) => selected.has(event.id ?? String(index)));
+    if (!selectedEvents.length) return;
+    const confirmed = window.confirm('Delete selected events?');
+    if (!confirmed) return;
+    onDeleteEvents(selectedEvents);
+    reset();
+  };
+
+  const renderList = (
+    title: string,
+    events: EventListItem[],
+    selected: Set<string>,
+    setSelected: (next: Set<string>) => void,
+    filterValue: string,
+    setFilterValue: (value: string) => void,
+    options: string[],
+  ) => (
+    <section className="event-collection">
+      <div className="event-collection-header">
+        <strong>{title}</strong>
+        <div className="event-collection-actions">
+          <select
+            className="event-type-filter"
+            aria-label={`${title} filter`}
+            value={filterValue}
+            onChange={(event) => setFilterValue(event.target.value)}
+          >
+            {options.map((option) => (
+              <option key={option} value={option}>
+                {option}
+              </option>
+            ))}
+          </select>
+          <button
+            type="button"
+            className="bulk-delete-btn"
+            onClick={() => handleBulkDelete(events, selected, () => setSelected(new Set()))}
+          >
+            <BulkDeleteIcon />
+            Delete
+          </button>
+        </div>
+      </div>
+      <div className="event-collection-list">
+        {events.length === 0 && <span>No events yet.</span>}
+        {events.map((event, index) => {
+          const key = event.id ?? String(index);
+          return (
+            <label key={key} className="event-collection-item">
+              <input
+                type="checkbox"
+                checked={selected.has(key)}
+                onChange={() => toggleSelection(selected, key, setSelected)}
+              />
+              <div>
+                <div style={{ display: 'flex', alignItems: 'center', gap: '0.6rem' }}>
+                  {event.imageUrl && <img src={event.imageUrl} alt={event.imageAlt || event.title} />}
+                  <div>
+                    <strong>{event.title || 'Untitled event'}</strong>
+                    <div style={{ fontSize: '0.8rem', color: 'rgba(226,232,240,0.7)' }}>{event.type}</div>
+                  </div>
+                </div>
+              </div>
+            </label>
+          );
+        })}
+      </div>
+    </section>
+  );
+
+  return (
+    <div style={{ display: 'flex', flexDirection: 'column', gap: '1.5rem' }}>
+      {renderList(
+        'Upcoming',
+        filteredUpcoming,
+        selectedUpcoming,
+        setSelectedUpcoming,
+        upcomingType,
+        setUpcomingType,
+        upcomingOptions,
+      )}
+      {renderList(
+        'Archived',
+        filteredArchived,
+        selectedArchived,
+        setSelectedArchived,
+        archivedType,
+        setArchivedType,
+        archivedOptions,
+      )}
+    </div>
+  );
+};
+
+export default EventCollectionsPanel;

--- a/src/components/modals/EventModalShell.tsx
+++ b/src/components/modals/EventModalShell.tsx
@@ -1,0 +1,122 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { createPortal } from 'react-dom';
+import EventForm from '../forms/EventForm';
+import type { EventDataInput, EventFormProps } from '../forms/EventForm';
+import type { EventFormValues } from '../../utils/formValidators';
+import EventCollectionsPanel, { type EventListItem } from './EventCollectionsPanel';
+import './EventModals.css';
+
+type EventModalShellProps = {
+  isOpen: boolean;
+  title: string;
+  mode: EventFormProps['mode'];
+  eventData?: EventDataInput;
+  onClose: () => void;
+  onSubmit: (data: EventFormValues) => void;
+  upcomingEvents?: EventListItem[];
+  archivedEvents?: EventListItem[];
+  onDeleteEvents?: (events: EventListItem[]) => void;
+};
+
+const EventModalShell = ({
+  isOpen,
+  title,
+  mode,
+  eventData,
+  onClose,
+  onSubmit,
+  upcomingEvents,
+  archivedEvents,
+  onDeleteEvents,
+}: EventModalShellProps) => {
+  const modalRef = useRef<HTMLDivElement | null>(null);
+  const headerRef = useRef<HTMLDivElement | null>(null);
+  const footerRef = useRef<HTMLDivElement | null>(null);
+  const [bodyHeight, setBodyHeight] = useState<number | null>(null);
+
+  const modalContent = useMemo(() => {
+    if (!isOpen) return null;
+    return (
+      <div className="event-modal-overlay" role="presentation" onClick={onClose}>
+        <div
+          className="event-modal"
+          ref={modalRef}
+          role="dialog"
+          aria-modal="true"
+          aria-label={title}
+          onClick={(event) => event.stopPropagation()}
+        >
+          <div className="event-modal-header" ref={headerRef}>
+            <span className="event-modal-title">{title}</span>
+            <button type="button" className="event-modal-close" onClick={onClose}>
+              Close
+            </button>
+          </div>
+          <div className="event-modal-body" style={bodyHeight ? { height: bodyHeight } : undefined}>
+            <div className="event-modal-layout">
+              <EventForm eventData={eventData} mode={mode} onSubmit={onSubmit} onCancel={onClose} />
+              <EventCollectionsPanel
+                upcomingEvents={upcomingEvents}
+                archivedEvents={archivedEvents}
+                onDeleteEvents={onDeleteEvents}
+              />
+            </div>
+          </div>
+          <div className="event-modal-footer" ref={footerRef}>
+            <span>Tip: Use filters to focus on event types.</span>
+          </div>
+        </div>
+      </div>
+    );
+  }, [
+    archivedEvents,
+    bodyHeight,
+    eventData,
+    isOpen,
+    mode,
+    onClose,
+    onDeleteEvents,
+    onSubmit,
+    title,
+    upcomingEvents,
+  ]);
+
+  useLayoutEffect(() => {
+    if (!isOpen) return;
+    const updateBodyHeight = () => {
+      if (!modalRef.current) return;
+      const headerHeight = headerRef.current?.offsetHeight ?? 0;
+      const footerHeight = footerRef.current?.offsetHeight ?? 0;
+      const containerHeight = modalRef.current.clientHeight;
+      const nextHeight = Math.max(containerHeight - headerHeight - footerHeight, 0);
+      setBodyHeight(nextHeight);
+    };
+
+    updateBodyHeight();
+    const observer = new ResizeObserver(updateBodyHeight);
+    if (modalRef.current) observer.observe(modalRef.current);
+    if (headerRef.current) observer.observe(headerRef.current);
+    if (footerRef.current) observer.observe(footerRef.current);
+    window.addEventListener('resize', updateBodyHeight);
+
+    return () => {
+      observer.disconnect();
+      window.removeEventListener('resize', updateBodyHeight);
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return undefined;
+    const { overflow } = document.body.style;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.body.style.overflow = overflow;
+    };
+  }, [isOpen]);
+
+  if (!isOpen) return null;
+
+  return createPortal(modalContent, document.body);
+};
+
+export default EventModalShell;

--- a/src/components/modals/EventModals.css
+++ b/src/components/modals/EventModals.css
@@ -1,0 +1,146 @@
+.event-modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.72);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 1.5rem;
+  z-index: 1000;
+}
+
+.event-modal {
+  width: min(960px, 96vw);
+  max-height: 80vh;
+  background: rgba(2, 6, 23, 0.95);
+  border-radius: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 24px 80px rgba(15, 23, 42, 0.4);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+
+.event-modal-header,
+.event-modal-footer {
+  padding: 1.25rem 1.5rem;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.16);
+}
+
+.event-modal-footer {
+  border-top: 1px solid rgba(148, 163, 184, 0.16);
+  border-bottom: none;
+}
+
+.event-modal-title {
+  font-size: 1.2rem;
+  font-weight: 600;
+  color: #f8fafc;
+}
+
+.event-modal-close {
+  border: none;
+  background: rgba(148, 163, 184, 0.2);
+  color: #e2e8f0;
+  border-radius: 999px;
+  padding: 0.35rem 0.7rem;
+  cursor: pointer;
+}
+
+.event-modal-body {
+  padding: 1.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  overflow: hidden;
+}
+
+.event-modal-layout {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 320px);
+  gap: 2rem;
+}
+
+.event-collection {
+  background: rgba(15, 23, 42, 0.6);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.event-collection-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.5rem;
+}
+
+.event-collection-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 240px;
+  overflow: hidden;
+}
+
+.event-collection-item {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  gap: 0.75rem;
+  align-items: center;
+  padding: 0.75rem;
+  border-radius: 0.9rem;
+  background: rgba(2, 6, 23, 0.65);
+  border: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.event-collection-item img {
+  width: 48px;
+  height: 48px;
+  border-radius: 0.75rem;
+  object-fit: cover;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+}
+
+.event-collection-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.bulk-delete-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+  border: none;
+  padding: 0.4rem 0.8rem;
+  border-radius: 999px;
+  background: rgba(239, 68, 68, 0.2);
+  color: #fecaca;
+  cursor: pointer;
+}
+
+.event-type-filter {
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(2, 6, 23, 0.6);
+  color: inherit;
+  padding: 0.3rem 0.8rem;
+}
+
+@media (max-width: 900px) {
+  .event-modal-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .event-collection-list {
+    max-height: none;
+  }
+}

--- a/src/utils/formValidators.ts
+++ b/src/utils/formValidators.ts
@@ -1,0 +1,107 @@
+import { isAfter, isValid } from 'date-fns';
+
+export const MAX_IMAGE_SIZE_BYTES = 5 * 1024 * 1024;
+
+export type EventImageMeta = {
+  width?: number;
+  height?: number;
+  size?: number;
+  type?: string;
+};
+
+export type EventFormValues = {
+  title: string;
+  description: string;
+  start: Date;
+  end: Date;
+  type: string;
+  location: string;
+  imageUrl?: string;
+  imageAlt?: string;
+  imageMeta?: EventImageMeta | null;
+};
+
+export type EventFormErrors = Partial<Record<keyof EventFormValues, string>>;
+
+export const validateEventForm = (values: EventFormValues): EventFormErrors => {
+  const errors: EventFormErrors = {};
+
+  if (!values.title.trim()) {
+    errors.title = 'Title is required.';
+  }
+
+  if (!isValid(values.start)) {
+    errors.start = 'Start date is invalid.';
+  }
+
+  if (!isValid(values.end)) {
+    errors.end = 'End date is invalid.';
+  }
+
+  if (isValid(values.start) && isValid(values.end) && isAfter(values.start, values.end)) {
+    errors.end = 'End date must be after the start date.';
+  }
+
+  if (values.imageMeta?.size && values.imageMeta.size > MAX_IMAGE_SIZE_BYTES) {
+    errors.imageUrl = 'Image must be smaller than 5MB.';
+  }
+
+  return errors;
+};
+
+export const normalizeEventValues = (values: EventFormValues) => ({
+  ...values,
+  title: values.title.trim(),
+  description: values.description.trim(),
+  location: values.location.trim(),
+  start: values.start.toISOString(),
+  end: values.end.toISOString(),
+});
+
+export const analyzeImage = async (file: File) => {
+  if (file.size > MAX_IMAGE_SIZE_BYTES) {
+    return {
+      dataUrl: '',
+      altText: '',
+      metadata: {
+        size: file.size,
+        type: file.type,
+      } satisfies EventImageMeta,
+      error: 'File exceeds 5MB limit.',
+    };
+  }
+
+  const dataUrl = await new Promise<string>((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(new Error('Unable to read image file.'));
+    reader.readAsDataURL(file);
+  });
+
+  const metadata = await new Promise<EventImageMeta>((resolve) => {
+    const image = new Image();
+    image.onload = () => {
+      resolve({
+        width: image.width,
+        height: image.height,
+        size: file.size,
+        type: file.type,
+      });
+    };
+    image.onerror = () => {
+      resolve({
+        size: file.size,
+        type: file.type,
+      });
+    };
+    image.src = dataUrl;
+  });
+
+  const altText = file.name.replace(/[-_]/g, ' ').replace(/\.[^/.]+$/, '').trim();
+
+  return {
+    dataUrl,
+    altText,
+    metadata,
+  };
+};


### PR DESCRIPTION
### Motivation
- Improve event create/edit UX by providing portal-based modals that fit the viewport and avoid parent layout scroll issues. 
- Make forms robust for edit-mode population, timezone-safe date parsing, and change-detection to prevent accidental no-op saves. 
- Add image upload/analysis and collection-side UI (filters + bulk delete) so events can include media and admins can manage lists efficiently.

### Description
- Added a portal modal shell `src/components/modals/EventModalShell.tsx` that computes an internal body height with `ResizeObserver` and renders via `createPortal` to keep overlays independent of parent layouts. 
- Implemented `src/components/forms/EventForm.tsx` and `src/components/forms/useEventForm.ts` providing isolated form state, date parsing with `date-fns`, edit-mode population (`useEffect` + reset), change-detection, optional accordions, and an image upload/preview flow. 
- Added `src/utils/formValidators.ts` with shared validation helpers, `analyzeImage` (client-side `FileReader` + `Image` metadata extraction) and a 5MB size guard. 
- Created a collections sidebar `src/components/modals/EventCollectionsPanel.tsx` with client-side event-type filtering (`<select>`), checkbox selection, and a bulk-delete action with user confirmation, plus `CreateEventModal.tsx` and `EditEventModal.tsx` thin wrappers. 
- Added modal and form styles in `src/components/modals/EventModals.css` and `src/components/forms/EventForm.css` to ensure `max-height: 80vh`, internal overflow control, responsive grid fallbacks, and accordion behaviour.

### Testing
- No automated tests or CI runs were executed against these changes as part of this PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976c4922398832e80de2d9d71148698)