### PR TITLE
Enhanced Calendar Views and Rendering with Overlap and Year Improvements

### DIFF
--- a/src/components/Calendar/Calendar.jsx
+++ b/src/components/Calendar/Calendar.jsx
@@ -7,7 +7,7 @@ import YearView from './YearView';
 import './Calendar.css';
 
 const Calendar = () => {
-  const { view } = useCalendar();
+  const { view, setCurrentDate } = useCalendar();
 
   const renderView = () => {
     switch (view) {
@@ -18,7 +18,7 @@ const Calendar = () => {
       case CALENDAR_VIEWS.MONTH:
         return <MonthView key="month" />;
       case CALENDAR_VIEWS.YEAR:
-        return <YearView key="year" />;
+        return <YearView key="year" onYearChange={setCurrentDate} />;
       default:
         return <MonthView key="month" />;
     }

--- a/src/components/Calendar/DayView.css
+++ b/src/components/Calendar/DayView.css
@@ -61,46 +61,75 @@
   padding: 0.45rem 0.9rem;
 }
 
-.day-list-wrapper {
+.day-grid {
   flex: 1;
-  display: flex;
-  flex-direction: column;
-  padding: 1rem;
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  border-radius: 16px;
   overflow: hidden;
   min-height: 0;
+  --hour-height: 32px;
 }
 
-.day-list {
+.day-time-column {
+  display: grid;
+  grid-template-rows: repeat(24, var(--hour-height));
+  border-right: 1px solid var(--glass-border);
+  background: rgba(15, 23, 42, 0.35);
+}
+
+.day-time-slot {
   display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  height: 100%;
+  align-items: center;
+  justify-content: flex-end;
+  padding: 0 0.75rem;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.day-grid-body {
+  position: relative;
+  display: grid;
+  grid-template-rows: repeat(24, var(--hour-height));
+}
+
+.day-hour-cell {
+  border-bottom: 1px solid rgba(255, 255, 255, 0.05);
+}
+
+.day-events-layer {
+  position: absolute;
+  inset: 0;
+  pointer-events: none;
 }
 
 .day-event-card {
+  position: absolute;
   display: flex;
   flex-direction: column;
   justify-content: center;
   gap: 0.35rem;
-  padding: 0.5rem 0.85rem;
-  border-radius: 14px;
-  border: 1px solid rgba(148, 163, 184, 0.2);
-  background: rgba(15, 23, 42, 0.6);
+  padding: 0.5rem 0.75rem;
+  border-radius: 12px;
+  border: 1px solid rgba(148, 163, 184, 0.25);
   color: var(--text-primary);
   text-align: left;
   cursor: pointer;
-  transition: transform 0.2s ease, background 0.2s ease, height 0.2s ease;
+  pointer-events: auto;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.25);
+  transition: transform 0.2s ease, background 0.2s ease;
+  overflow: hidden;
 }
 
 .day-event-card:hover,
-.day-event-card.is-focused {
-  background: rgba(24, 33, 61, 0.8);
+.day-event-card:focus-visible {
   transform: translateY(-1px);
 }
 
 .day-event-card.past-event {
-  opacity: 0.55;
-  filter: grayscale(0.3);
+  opacity: 0.7;
+  filter: grayscale(80%);
 }
 
 .day-event-card .event-time {
@@ -127,7 +156,8 @@
 }
 
 .day-empty-state {
-  flex: 1;
+  position: absolute;
+  inset: 0;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -135,17 +165,12 @@
   text-align: center;
   gap: 0.35rem;
   color: var(--text-muted);
+  pointer-events: none;
 }
 
 .day-empty-state .empty-title {
   font-weight: 700;
   color: var(--text-primary);
-}
-
-.day-overflow-hint {
-  text-align: right;
-  font-size: 0.75rem;
-  color: var(--text-muted);
 }
 
 @media (max-width: 900px) {
@@ -164,5 +189,9 @@
 @media (max-width: 600px) {
   .day-event-card .event-snippet {
     white-space: normal;
+  }
+
+  .day-grid {
+    grid-template-columns: 55px 1fr;
   }
 }

--- a/src/components/Calendar/DayView.jsx
+++ b/src/components/Calendar/DayView.jsx
@@ -1,13 +1,22 @@
 import { motion } from 'framer-motion';
-import { useEffect, useRef, useState } from 'react';
+import { useRef } from 'react';
 import { useCalendar } from '../../contexts/CalendarContext';
 import { useEvents } from '../../contexts/EventsContext';
 import { cn, getEventColor, formatDuration } from '../../utils/helpers';
-import { countRemainingEvents, formatFullDate, formatTime, getRelativeDayLabel, sortEventsByStart } from '../../utils/dateUtils';
+import {
+  countRemainingEvents,
+  formatFullDate,
+  formatTime,
+  formatTime24,
+  getDayHours,
+  getEventPosition,
+  getRelativeDayLabel,
+  sortEventsByStart
+} from '../../utils/dateUtils';
 import { Clock, Plus } from 'lucide-react';
+import { useHourScale } from '../../utils/useHourScale';
+import { layoutOverlappingEvents } from '../../utils/eventLayout';
 import './DayView.css';
-
-const MAX_VISIBLE_EVENTS = 30;
 
 const buildEventSnippet = (event) => {
   const pieces = [];
@@ -27,33 +36,13 @@ const buildEventSnippet = (event) => {
 const DayView = () => {
   const { currentDate, openEventModal } = useCalendar();
   const { getEventsForDate } = useEvents();
-  const [hoveredIndex, setHoveredIndex] = useState(null);
-  const [layout, setLayout] = useState({ base: 36, expanded: 48, compressed: 32 });
-  const listRef = useRef(null);
+  const dayGridRef = useRef(null);
 
   const dayEvents = sortEventsByStart(getEventsForDate(currentDate));
   const now = new Date();
   const remainingCount = countRemainingEvents(dayEvents, now);
-  const visibleEvents = dayEvents.slice(0, MAX_VISIBLE_EVENTS);
-
-  useEffect(() => {
-    const container = listRef.current;
-    if (!container) return;
-
-    const updateLayout = () => {
-      const available = container.clientHeight;
-      const count = Math.max(visibleEvents.length, 1);
-      const base = Math.max(22, Math.min(46, available / count));
-      const expanded = Math.min(base * 1.4, base + 20);
-      const compressed = count > 1 ? Math.max(18, (available - expanded) / (count - 1)) : base;
-      setLayout({ base, expanded, compressed });
-    };
-
-    updateLayout();
-    const observer = new ResizeObserver(updateLayout);
-    observer.observe(container);
-    return () => observer.disconnect();
-  }, [visibleEvents.length, currentDate]);
+  const dayHours = getDayHours();
+  const pixelsPerHour = useHourScale({ containerRef: dayGridRef, offset: 24, fitToViewport: true });
 
   const handleAddEvent = () => {
     const startTime = new Date(currentDate);
@@ -76,11 +65,15 @@ const DayView = () => {
         <div className="day-stats">
           <div className="stat">
             <span className="stat-number">{remainingCount}</span>
-            <span className="stat-label">Remaining</span>
+            <span className="stat-label">
+              {`event${remainingCount !== 1 ? 's' : ''} remaining`}
+            </span>
           </div>
           <div className="stat">
             <span className="stat-number">{dayEvents.length}</span>
-            <span className="stat-label">Total</span>
+            <span className="stat-label">
+              {`event${dayEvents.length !== 1 ? 's' : ''} total`}
+            </span>
           </div>
           <button className="btn btn-primary day-add-btn" onClick={handleAddEvent}>
             <Plus size={16} /> Add Event
@@ -88,36 +81,51 @@ const DayView = () => {
         </div>
       </div>
 
-      <div className="day-list-wrapper glass-card" ref={listRef}>
-        {visibleEvents.length === 0 ? (
-          <div className="day-empty-state">
-            <div className="empty-title">No events scheduled</div>
-            <div className="empty-subtitle">Add something for this day to get started.</div>
-          </div>
-        ) : (
-          <div className="day-list" role="list">
-            {visibleEvents.map((event, index) => {
-              const isPastEvent = new Date(event.end || event.start) < now;
-              const height = hoveredIndex === null
-                ? layout.base
-                : hoveredIndex === index
-                  ? layout.expanded
-                  : layout.compressed;
+      <div
+        className="day-grid glass-card"
+        ref={dayGridRef}
+        style={{ '--hour-height': `${pixelsPerHour}px` }}
+        role="grid"
+        aria-label="Day schedule"
+      >
+        <div className="day-time-column">
+          {dayHours.map((hour) => (
+            <div key={hour.getHours()} className="day-time-slot">
+              {formatTime24(hour)}
+            </div>
+          ))}
+        </div>
 
+        <div className="day-grid-body">
+          {dayHours.map((hour) => (
+            <div key={`hour-${hour.getHours()}`} className="day-hour-cell" />
+          ))}
+
+          <div className="day-events-layer">
+            {layoutOverlappingEvents(dayEvents).map(({ event, column, columns }, index) => {
+              const { top, height: rawHeight } = getEventPosition(event, currentDate, pixelsPerHour);
+              const height = Math.max(rawHeight * 0.7, 18);
+              const isPastEvent = new Date(event.end || event.start) < now;
+              const gap = 6;
+              const width = `calc((100% / ${columns}) - ${gap}px)`;
+              const left = `calc(${column} * (100% / ${columns}) + ${gap / 2}px)`;
               return (
-                <button
+                <motion.button
                   key={event.id}
                   type="button"
-                  className={cn('day-event-card', isPastEvent && 'past-event', hoveredIndex === index && 'is-focused')}
+                  className={cn('day-event-card', isPastEvent && 'past-event')}
                   style={{
+                    top: `${top}px`,
                     height: `${height}px`,
-                    borderColor: event.color || getEventColor(event.category)
+                    left,
+                    width,
+                    zIndex: 5 + column,
+                    backgroundColor: event.color || getEventColor(event.category)
                   }}
                   onClick={() => openEventModal(event)}
-                  onMouseEnter={() => setHoveredIndex(index)}
-                  onMouseLeave={() => setHoveredIndex(null)}
-                  onFocus={() => setHoveredIndex(index)}
-                  onBlur={() => setHoveredIndex(null)}
+                  initial={{ opacity: 0, scale: 0.95 }}
+                  animate={{ opacity: 1, scale: 1 }}
+                  transition={{ delay: index * 0.04 }}
                 >
                   <div className="event-time">
                     <Clock size={12} />
@@ -127,18 +135,19 @@ const DayView = () => {
                     <span className="event-duration">{formatDuration(event.start, event.end)}</span>
                   </div>
                   <div className="event-snippet">{buildEventSnippet(event)}</div>
-                </button>
+                </motion.button>
               );
             })}
           </div>
-        )}
-      </div>
 
-      {dayEvents.length > MAX_VISIBLE_EVENTS && (
-        <div className="day-overflow-hint">
-          Showing {MAX_VISIBLE_EVENTS} of {dayEvents.length} events
+          {dayEvents.length === 0 && (
+            <div className="day-empty-state">
+              <div className="empty-title">No events scheduled</div>
+              <div className="empty-subtitle">Add something for this day to get started.</div>
+            </div>
+          )}
         </div>
-      )}
+      </div>
     </motion.div>
   );
 };

--- a/src/components/Calendar/MonthView.css
+++ b/src/components/Calendar/MonthView.css
@@ -163,8 +163,8 @@
 }
 
 .day-event.past-event {
-  opacity: 0.55;
-  filter: grayscale(0.4);
+  opacity: 0.7;
+  filter: grayscale(80%);
   transform: scale(0.96);
 }
 

--- a/src/components/Calendar/MonthView.jsx
+++ b/src/components/Calendar/MonthView.jsx
@@ -47,8 +47,7 @@ const MonthView = () => {
       <div className="month-summary glass-card">
         <div className="month-summary-title">This Month</div>
         <div className="month-summary-stat">
-          <span className="stat-number">{monthEventsCount}</span>
-          <span className="stat-label">Events</span>
+          {`${monthEventsCount} event${monthEventsCount !== 1 ? 's' : ''}`}
         </div>
       </div>
 
@@ -116,7 +115,7 @@ const MonthView = () => {
                 
                 {dayEvents.length > 3 && (
                   <div className="more-events">
-                    +{dayEvents.length - 3} more
+                    {`+${dayEvents.length - 3} more event${dayEvents.length - 3 !== 1 ? 's' : ''}`}
                   </div>
                 )}
               </div>

--- a/src/components/Calendar/WeekView.css
+++ b/src/components/Calendar/WeekView.css
@@ -182,8 +182,8 @@
 }
 
 .week-event.past-event {
-  opacity: 0.55;
-  filter: grayscale(0.4);
+  opacity: 0.7;
+  filter: grayscale(80%);
   transform: scale(0.97);
 }
 

--- a/src/components/Calendar/WeekView.jsx
+++ b/src/components/Calendar/WeekView.jsx
@@ -85,8 +85,7 @@ const WeekView = () => {
       <div className="week-summary glass-card">
         <div className="week-summary-title">This Week</div>
         <div className="week-summary-stat">
-          <span className="stat-number">{weekEventsCount}</span>
-          <span className="stat-label">Events</span>
+          {`${weekEventsCount} event${weekEventsCount !== 1 ? 's' : ''}`}
         </div>
       </div>
 
@@ -135,8 +134,9 @@ const WeekView = () => {
                     const { top, height: rawHeight } = getEventPosition(event, day, pixelsPerHour);
                     const height = Math.max(rawHeight * 0.7, 18);
                     const isPastEvent = new Date(event.end || event.start) < now;
-                    const width = `${100 / columns}%`;
-                    const left = `calc(${column * (100 / columns)}% + 2px)`;
+                    const gap = 6;
+                    const width = `calc((100% / ${columns}) - ${gap}px)`;
+                    const left = `calc(${column} * (100% / ${columns}) + ${gap / 2}px)`;
                     const showLocation = height > 42;
                     return (
                       <motion.div
@@ -147,7 +147,8 @@ const WeekView = () => {
                           height: `${height}px`,
                           backgroundColor: event.color || getEventColor(event.category),
                           width,
-                          left
+                          left,
+                          zIndex: 5 + column
                         }}
                         onClick={(e) => handleEventClick(event, e)}
                         initial={{ opacity: 0, scale: 0.95 }}

--- a/src/components/Calendar/YearView.css
+++ b/src/components/Calendar/YearView.css
@@ -28,6 +28,7 @@
   display: flex;
   align-items: center;
   gap: 1rem;
+  flex-wrap: wrap;
 }
 
 .year-mode-toggle {
@@ -55,48 +56,61 @@
   font-weight: 700;
 }
 
+.year-select {
+  display: inline-flex;
+  align-items: center;
+}
+
+.year-select select {
+  background: rgba(15, 23, 42, 0.6);
+  color: var(--text-primary);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 0.75rem;
+}
+
+.year-view .sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
 .year-grid {
-  padding: 1.5rem 2rem;
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
   gap: 1rem;
 }
 
-.year-month-labels {
+.year-month {
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.year-month-title {
+  font-weight: 700;
+  font-size: 0.95rem;
+  color: var(--text-primary);
+}
+
+.year-month-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(18px, 1fr));
-  gap: 4px;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-}
-
-.month-label {
-  opacity: 0.2;
-}
-
-.month-label.visible {
-  opacity: 0.9;
-}
-
-.year-weeks {
-  display: grid;
-  grid-auto-flow: column;
-  grid-auto-columns: minmax(18px, 1fr);
-  gap: 4px;
-  align-items: start;
-}
-
-.year-week-column {
-  display: grid;
-  grid-template-rows: repeat(7, 1fr);
+  grid-template-columns: repeat(7, minmax(20px, 1fr));
   gap: 4px;
 }
 
 .year-day {
-  width: 18px;
-  height: 18px;
+  position: relative;
+  min-width: 20px;
+  min-height: 20px;
   border-radius: 6px;
   background: rgba(148, 163, 184, 0.2);
   border: 1px solid rgba(148, 163, 184, 0.25);
@@ -104,9 +118,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: 0.6rem;
+  font-size: 0.65rem;
   font-weight: 700;
   color: var(--text-primary);
+}
+
+.year-day.outside-month {
+  opacity: 0.35;
 }
 
 .year-day.level-1 {
@@ -129,59 +147,25 @@
   border-color: rgba(253, 186, 248, 0.8);
 }
 
+.year-day.past-event {
+  opacity: 0.7;
+  filter: grayscale(80%);
+}
+
+.year-day-number {
+  position: absolute;
+  top: 2px;
+  right: 2px;
+  font-size: 0.55rem;
+  opacity: 0.8;
+}
+
 .year-day-count {
   line-height: 1;
 }
 
-.year-legend {
-  display: flex;
-  align-items: center;
-  gap: 0.5rem;
-  font-size: 0.75rem;
-  color: var(--text-muted);
-}
-
-.legend-scale {
-  display: flex;
-  gap: 4px;
-}
-
-.legend-dot {
-  width: 18px;
-  height: 18px;
-  border-radius: 6px;
-  background: rgba(148, 163, 184, 0.2);
-  border: 1px solid rgba(148, 163, 184, 0.25);
-}
-
-.legend-dot.level-1 {
-  background: rgba(167, 197, 255, 0.4);
-  border-color: rgba(167, 197, 255, 0.6);
-}
-
-.legend-dot.level-2 {
-  background: rgba(186, 230, 253, 0.55);
-  border-color: rgba(186, 230, 253, 0.7);
-}
-
-.legend-dot.level-3 {
-  background: rgba(216, 180, 254, 0.6);
-  border-color: rgba(216, 180, 254, 0.7);
-}
-
-.legend-dot.level-4 {
-  background: rgba(253, 186, 248, 0.7);
-  border-color: rgba(253, 186, 248, 0.8);
-}
-
 @media (max-width: 1024px) {
-  .year-grid {
+  .year-header {
     padding: 1.25rem;
-  }
-
-  .year-day,
-  .legend-dot {
-    width: 14px;
-    height: 14px;
   }
 }

--- a/src/utils/eventLayout.js
+++ b/src/utils/eventLayout.js
@@ -1,23 +1,41 @@
-export const layoutOverlappingEvents = (events) => {
+const getSafeEventEnd = (event) => {
+  const start = new Date(event.start);
+  const rawEnd = new Date(event.end || event.start);
+  if (Number.isNaN(rawEnd.getTime())) {
+    return new Date(start.getTime() + 15 * 60 * 1000);
+  }
+  if (rawEnd <= start) {
+    return new Date(start.getTime() + 15 * 60 * 1000);
+  }
+  return rawEnd;
+};
+
+export const layoutOverlappingEvents = (events, { maxColumns = 10 } = {}) => {
   const sorted = [...events].sort((a, b) => new Date(a.start) - new Date(b.start));
   const positioned = [];
   let active = [];
 
   sorted.forEach((event) => {
     const start = new Date(event.start);
+    const end = getSafeEventEnd(event);
 
-    active = active.filter(entry => new Date(entry.event.end) > start);
+    active = active.filter(entry => entry.end > start);
     const usedColumns = new Set(active.map(entry => entry.column));
     let column = 0;
-    while (usedColumns.has(column)) column += 1;
+    while (usedColumns.has(column) && column < maxColumns) {
+      column += 1;
+    }
+    if (column >= maxColumns) {
+      column = maxColumns - 1;
+    }
 
-    const entry = { event, column, columns: 1 };
+    const entry = { event, column, columns: 1, end };
     active.push(entry);
     positioned.push(entry);
 
-    const maxColumns = Math.max(...active.map(item => item.column)) + 1;
+    const overlapCount = Math.min(active.length, maxColumns);
     active.forEach(item => {
-      item.columns = Math.max(item.columns, maxColumns);
+      item.columns = Math.max(item.columns, overlapCount);
     });
   });
 


### PR DESCRIPTION
### Motivation
- Improve visual layout and correctness of calendar views by handling overlapping timed events so they render side-by-side without layout leaks. 
- Make past events visually distinct while preserving interactivity and unify count/label formatting across views. 
- Replace the previous small-year overview with a responsive, accessible year grid and add a controlled year chooser wired to the calendar state.

### Description
- Implemented an overlap-aware collision algorithm and safe end handling in `src/utils/eventLayout.js` (new `getSafeEventEnd`, `layoutOverlappingEvents` with a `maxColumns` clamp defaulting to 10) so day/week layouts compute `column` and `columns` for each event. 
- Reworked `DayView` and adjusted `WeekView` to render a time-grid (uses `useHourScale`) and position sized events absolutely using `getEventPosition` combined with `layoutOverlappingEvents`; widths use `calc(100% / columns)` with a small gap, and events get per-column `z-index` layering for visibility (files: `src/components/Calendar/DayView.jsx`, `src/components/Calendar/WeekView.jsx`, `src/components/Calendar/DayView.css`, `src/components/Calendar/WeekView.css`). 
- Normalized past-event visualization and pluralized summary labels across views by applying `.past-event { filter: grayscale(80%); opacity: 0.7; }` in CSS and switching to template literals like ``${count} event${count !== 1 ? 's' : ''}`` (files: `MonthView.jsx`, `WeekView.jsx`, `DayView.jsx`, `YearView.jsx` and related CSS). 
- Refactored `YearView` into a responsive CSS Grid of months using `grid-template-columns: repeat(auto-fit, minmax(200px, 1fr))`, memoized `YearDayCell` for per-day rendering with an absolute day number in the upper-right, and added a controlled year `<select>` with ±10 years wired to the calendar via a callback prop (`onYearChange` mapped to `setCurrentDate` in `Calendar.jsx`) (files: `src/components/Calendar/YearView.jsx`, `src/components/Calendar/YearView.css`, `src/components/Calendar/Calendar.jsx`). 

### Testing
- Ran the dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and confirmed the app booted successfully (server listening), performing an automated Playwright snapshot of the year view which completed and produced `artifacts/calendar-year-view.png`. 
- Performed automated rendering/smoke checks via the Playwright run (screenshot generation) and verified there were no runtime errors during the session; visual checks included verifying past-event greying and the responsive year grid (tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976c488b520832e8d05017d9202df49)