### PR TITLE
Fix policy page ad slot initialization

### DIFF
--- a/src/pages/PolicyLayout.jsx
+++ b/src/pages/PolicyLayout.jsx
@@ -1,20 +1,72 @@
+import { useEffect } from 'react';
 import { Link } from 'react-router-dom';
-import ReactGoogleAdsense from 'react-google-adsense';
 import './PolicyPages.css';
 
 const ADSENSE_CLIENT = import.meta.env.VITE_ADSENSE_CLIENT || 'ca-pub-0000000000000000';
 const ADSENSE_SLOT = import.meta.env.VITE_ADSENSE_SLOT || '0000000000';
+const ADSENSE_SCRIPT_ID = 'google-ads-sdk';
+const ADSENSE_SCRIPT_SRC = '//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js';
 
-export const AdSlot = ({ className }) => (
-  <div className={`policy-ad ${className || ''}`.trim()}>
-    <ReactGoogleAdsense
-      client={ADSENSE_CLIENT}
-      slot={ADSENSE_SLOT}
-      style={{ display: 'block' }}
-      format="auto"
-    />
-  </div>
-);
+const ensureAdsenseScript = () => {
+  if (typeof document === 'undefined') return null;
+  const existing = document.getElementById(ADSENSE_SCRIPT_ID);
+  if (existing) return existing;
+
+  const script = document.createElement('script');
+  script.id = ADSENSE_SCRIPT_ID;
+  script.async = true;
+  script.src = ADSENSE_SCRIPT_SRC;
+  document.body.appendChild(script);
+  return script;
+};
+
+export const AdSlot = ({ className }) => {
+  useEffect(() => {
+    if (typeof window === 'undefined') return undefined;
+
+    const script = ensureAdsenseScript();
+
+    const pushAd = () => {
+      try {
+        (window.adsbygoogle = window.adsbygoogle || []).push({});
+      } catch (error) {
+        console.warn('Adsense failed to load', error);
+      }
+    };
+
+    if (!script) {
+      return undefined;
+    }
+
+    if (script.dataset.loaded === 'true') {
+      pushAd();
+      return undefined;
+    }
+
+    const handleLoad = () => {
+      script.dataset.loaded = 'true';
+      pushAd();
+    };
+
+    script.addEventListener('load', handleLoad, { once: true });
+
+    return () => {
+      script.removeEventListener('load', handleLoad);
+    };
+  }, []);
+
+  return (
+    <div className={`policy-ad ${className || ''}`.trim()}>
+      <ins
+        className="adsbygoogle"
+        data-ad-client={ADSENSE_CLIENT}
+        data-ad-slot={ADSENSE_SLOT}
+        data-ad-format="auto"
+        style={{ display: 'block' }}
+      />
+    </div>
+  );
+};
 
 const PolicyLayout = ({ title, subtitle, children }) => (
   <div className="policy-page">


### PR DESCRIPTION
### Motivation
- The policy pages were loading a legacy `react-google-adsense` wrapper that dereferenced `PropTypes` from React and caused a runtime crash (`Cannot read properties of undefined (reading 'string')`).
- Replace the fragile third-party wrapper with a minimal, robust client-side ad slot loader to avoid the crash and support SSR-safe pages.

### Description
- Replaced the old `ReactGoogleAdsense` usage with an inline `AdSlot` component in `src/pages/PolicyLayout.jsx` that injects the Adsense script once and is guarded against server-side execution.
- The new loader safely attaches the `//pagead2.googlesyndication.com/pagead/js/adsbygoogle.js` script, listens for its `load` event, marks the script as loaded to prevent duplicate pushes, and calls `(window.adsbygoogle = window.adsbygoogle || []).push({})` inside a `try/catch` to avoid throwing on unsupported environments.
- Updated `PolicyLayout` to use the new `AdSlot` component for top and bottom ad placements and removed reliance on the external `react-google-adsense` wrapper.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976cccbedac832e8360cdb64c6448dc)