### PR TITLE
Event modals: fit to viewport, prefill image state, custom type dropdown & bulk delete

### DIFF
--- a/src/components/forms/EventForm.tsx
+++ b/src/components/forms/EventForm.tsx
@@ -61,6 +61,8 @@ const EventForm = ({ eventData, mode, onSubmit, onCancel }: EventFormProps) => {
   useEffect(() => {
     if (mode === 'edit' && eventData) {
       resetForm(buildInitialValues(eventData));
+      setImageStatus(eventData.imageUrl ? 'ready' : 'idle');
+      setImageError('');
     }
   }, [eventData, mode, resetForm]);
 

--- a/src/components/modals/EventModals.css
+++ b/src/components/modals/EventModals.css
@@ -11,7 +11,7 @@
 
 .event-modal {
   width: min(960px, 96vw);
-  max-height: 80vh;
+  max-height: 85vh;
   background: rgba(2, 6, 23, 0.95);
   border-radius: 1.5rem;
   border: 1px solid rgba(148, 163, 184, 0.2);
@@ -56,13 +56,15 @@
   display: flex;
   flex-direction: column;
   gap: 2rem;
-  overflow: hidden;
+  overflow: auto;
+  min-height: 0;
 }
 
 .event-modal-layout {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 320px);
   gap: 2rem;
+  min-height: 0;
 }
 
 .event-collection {
@@ -87,7 +89,7 @@
   flex-direction: column;
   gap: 0.75rem;
   max-height: 240px;
-  overflow: hidden;
+  overflow-y: auto;
 }
 
 .event-collection-item {
@@ -127,12 +129,56 @@
   cursor: pointer;
 }
 
-.event-type-filter {
+.bulk-delete-btn:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+}
+
+.event-type-dropdown {
+  position: relative;
+}
+
+.event-type-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
   border-radius: 999px;
   border: 1px solid rgba(148, 163, 184, 0.4);
   background: rgba(2, 6, 23, 0.6);
   color: inherit;
-  padding: 0.3rem 0.8rem;
+  padding: 0.3rem 0.75rem;
+  cursor: pointer;
+}
+
+.event-type-menu {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.4rem);
+  min-width: 160px;
+  background: rgba(2, 6, 23, 0.98);
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.2);
+  box-shadow: 0 12px 32px rgba(15, 23, 42, 0.5);
+  padding: 0.35rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  z-index: 5;
+}
+
+.event-type-option {
+  background: transparent;
+  border: none;
+  color: inherit;
+  text-align: left;
+  padding: 0.4rem 0.6rem;
+  border-radius: 0.55rem;
+  cursor: pointer;
+}
+
+.event-type-option:hover,
+.event-type-option.active {
+  background: rgba(99, 102, 241, 0.2);
 }
 
 @media (max-width: 900px) {


### PR DESCRIPTION
### Motivation
- Ensure create/edit event modals fit inside the viewport and scroll internally when necessary to avoid overlapping app chrome. 
- Make edit flows reliably pre-populate all fields including image state when opening a modal from calendar clicks. 
- Improve Upcoming/Archive collections UX with a custom "All Types" dropdown and enable multi-select bulk-deletes with a clearer bulk-trash affordance.

### Description
- Added a custom type dropdown and disabled/enabled bulk-delete button with checkbox multi-select support in `src/components/modals/EventCollectionsPanel.tsx`. 
- Replaced the native `select` with `TypeDropdown` and introduced a new bulk-trash SVG and selection logic to collect selected events and call `onDeleteEvents`. 
- Adjusted modal layout CSS in `src/components/modals/EventModals.css` to use `max-height: 85vh`, enable internal scrolling (`overflow: auto` / `min-height: 0`) and make collection lists scrollable, plus styles for the dropdown. 
- Synced seeded event image state for edit flows in `src/components/forms/EventForm.tsx` by setting `imageStatus` and clearing any image errors when `eventData` is applied.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`; the server launched but dependency pre-bundling reported unresolved imports (`react-router-dom`, `@mui/material`, `@mui/icons-material`, `react-google-adsense`) which prevented a full manual end-to-end flow. (failed)
- Attempted `npm start` which failed because there is no `start` script defined in `package.json`. (failed)
- Ran an automated headless browser script to capture the app home screenshot after the dev server was reachable and produced a screenshot artifact (`artifacts/event-modal-home.png`). (succeeded)
- No unit or integration tests were changed or added and no automated form submission tests were run due to dependency resolution issues. (not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976ccda5738832ebba7ee2beea223b6)