### PR TITLE
AI: clarification fallback, output sanitization, and input bar UX improvements

### DIFF
--- a/src/ai/OutputSanitizer.js
+++ b/src/ai/OutputSanitizer.js
@@ -1,4 +1,5 @@
 const NONCE_PATTERN = /\/nonce\s+\w+/gi;
+const VERIFICATION_LINE = /^\s*(verification|verified|confidence|analysis|final|assistant|response)\s*[:\-].*$/gim;
 const EXTRA_WHITESPACE = /\s{2,}/g;
 
 const isMathExpression = (input) => {
@@ -31,7 +32,12 @@ const evaluateMathExpression = (input) => {
 export const sanitizeAIOutput = (output, { input = '', verbose = false } = {}) => {
   if (typeof output !== 'string') return output;
 
-  let cleaned = output.replace(NONCE_PATTERN, '').replace(EXTRA_WHITESPACE, ' ').trim();
+  let cleaned = output
+    .replace(NONCE_PATTERN, '')
+    .replace(VERIFICATION_LINE, '')
+    .replace(/\n{2,}/g, '\n')
+    .replace(EXTRA_WHITESPACE, ' ')
+    .trim();
 
   if (isMathExpression(input)) {
     const result = evaluateMathExpression(input);

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -28,6 +28,7 @@
   gap: 0.75rem;
   flex-wrap: wrap;
   justify-content: center;
+  width: 100%;
 }
 
 .quick-event-form {
@@ -43,6 +44,11 @@
 
 .quick-event-form:hover {
   box-shadow: 0 0 5px rgba(0, 0, 0, 0.2);
+}
+
+.quick-event-form:focus-within {
+  border-color: rgba(92, 200, 255, 0.65);
+  box-shadow: 0 0 16px rgba(92, 200, 255, 0.2);
 }
 
 .quick-event-form.inline {
@@ -381,6 +387,18 @@
   .view-utility-row {
     flex-direction: column;
     width: 100%;
+  }
+
+  .quick-event-form {
+    width: 100%;
+  }
+
+  .quick-event-form.inline {
+    max-width: none;
+  }
+
+  .quick-event-input {
+    min-width: 0;
   }
 
   .view-dropdown {


### PR DESCRIPTION
### Motivation
- Improve calendar natural-language parsing so the assistant asks concise follow-ups when input is ambiguous instead of guessing. 
- Make local/WebLLM usage robust by falling back to deterministic rule-based parsing when the WebLLM is slow or unreliable. 
- Clean AI responses returned to the UI so non-content verification lines and nonces are removed while preserving simple math evaluations. 
- Improve the quick “Ask or add with Cal” input bar visual affordance and responsiveness so it’s centered next to the view controls and highlights on focus/hover.

### Description
- Add rule-based location extraction and surface it in drafts by parsing `at/in/@` patterns and excluding false positives like time tokens (`src/ai/AiProcessor.js`).
- Tighten confidence/clarification logic and treat a failing WebLLM benchmark as "unreliable" to prefer rule-based drafts and trigger clarification instead of guessing (`src/ai/AiProcessor.js`).
- Strip nonce tokens and verification/analysis-style lines plus collapse extra blank lines from AI outputs, and continue to evaluate simple math expressions (e.g. `3*4 -> 12`) (`src/ai/OutputSanitizer.js`).
- Center and highlight the quick AI input bar with a `:focus-within` visual treatment, ensure it fills available width on smaller screens, and relax the inline max-width for responsive layout (`src/components/Header/Header.css`).

### Testing
- Started a dev server with `npm run dev -- --host 0.0.0.0 --port 4173` and Vite reported ready, which indicates the app bundles and serves successfully. (Succeeded)
- Installed dependencies via `npm install` to resolve missing imports used by the dev server before testing. (Succeeded)
- Captured a headless browser screenshot of the running app to validate layout changes via a Playwright script; screenshot artifact was produced. (Succeeded)
- Did not run `npm start` (script not present) and did not exercise Google login flow due to interactive credential requirements. (Not run)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976cce0aa80832ebeb61bd524794485)