### PR TITLE
Refine header controls, tighten settings UI, and add privacy/terms/contact pages

### DIFF
--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -1,10 +1,10 @@
 .header {
-  padding: 10px 0;
+  padding: 6px 0;
   border-bottom: 1px solid var(--glass-border);
   position: sticky;
   top: 0;
   z-index: 100;
-  margin-bottom: 1rem;
+  margin-bottom: 0.75rem;
 }
 
 .logo-text {
@@ -25,7 +25,7 @@
 .view-utility-row {
   display: flex;
   align-items: center;
-  gap: 0.75rem;
+  gap: 0.6rem;
   flex-wrap: wrap;
   justify-content: center;
 }
@@ -33,8 +33,8 @@
 .quick-event-form {
   display: flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.4rem 0.6rem;
+  gap: 0.45rem;
+  padding: 0.35rem 0.55rem;
   border-radius: 999px;
   border: 1px solid var(--glass-border);
   background: var(--glass-strong);
@@ -46,7 +46,7 @@
 }
 
 .quick-event-form.inline {
-  max-width: 420px;
+  max-width: 360px;
 }
 
 .quick-event-icon {
@@ -68,13 +68,13 @@
 
 .quick-event-input {
   flex: 1;
-  min-width: 210px;
-  padding: 0.5rem 0.75rem;
+  min-width: 170px;
+  padding: 0.45rem 0.65rem;
   border: none;
   border-radius: 999px;
   background: transparent;
   color: var(--text-primary);
-  font-size: 0.9rem;
+  font-size: 0.85rem;
   font-weight: 500;
   transition: all 0.2s ease;
 }
@@ -132,9 +132,9 @@
 
 .header-content {
   display: grid;
-  grid-template-columns: minmax(180px, 240px) minmax(0, 1fr) minmax(320px, 420px);
+  grid-template-columns: minmax(170px, 220px) minmax(0, 1fr) minmax(300px, 420px);
   align-items: center;
-  gap: 1rem;
+  gap: 0.75rem;
 }
 
 .header-left {
@@ -166,7 +166,7 @@
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 0.5rem;
+  gap: 0.35rem;
 }
 
 .nav-controls {
@@ -181,31 +181,38 @@
   border-radius: 8px;
 }
 
-.today-btn {
-  padding: 0.45rem;
-  border-radius: 12px;
+.today-cta {
+  padding: 0.35rem 0.9rem;
+  border-radius: 999px;
   display: inline-flex;
   align-items: center;
   justify-content: center;
-}
-
-.icon-link {
-  border: 1px solid rgba(99, 102, 241, 0.3);
-  background: rgba(99, 102, 241, 0.12);
+  gap: 0.4rem;
+  border: 1px solid rgba(99, 102, 241, 0.35);
+  background: rgba(99, 102, 241, 0.14);
   color: var(--text-primary);
+  font-size: 0.85rem;
+  font-weight: 600;
   transition: all 0.2s ease;
 }
 
-.icon-link:hover {
+.today-cta:hover {
   border-color: var(--accent);
-  background: rgba(99, 102, 241, 0.2);
+  background: rgba(99, 102, 241, 0.24);
 }
 
 .header-title {
-  font-size: 1.3rem;
+  font-size: 1.2rem;
   font-weight: 600;
   text-align: center;
   margin: 0;
+}
+
+.header-subtitle {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--text-muted);
+  text-align: center;
 }
 
 .header-right {
@@ -216,103 +223,36 @@
   gap: 0.75rem;
 }
 
-.view-dropdown {
-  position: relative;
-  min-width: 240px;
-}
-
-.view-dropdown-trigger {
-  width: 100%;
-  border-radius: 16px;
-  padding: 0.55rem 0.75rem;
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 0.75rem;
+.view-switch {
+  display: inline-flex;
+  gap: 6px;
+  padding: 4px;
+  border-radius: 999px;
   border: 1px solid rgba(92, 200, 255, 0.3);
   background: rgba(12, 18, 34, 0.8);
-  color: var(--text-primary);
-  cursor: pointer;
-  transition: all 0.2s ease;
 }
 
-.view-dropdown-trigger:hover {
-  border-color: rgba(92, 200, 255, 0.6);
-  box-shadow: 0 0 18px rgba(92, 200, 255, 0.15);
-}
-
-.view-dropdown-trigger svg {
-  transition: transform 0.2s ease;
-}
-
-.view-dropdown-label {
-  display: flex;
-  flex-direction: column;
-  text-align: left;
-}
-
-.view-dropdown-title {
-  font-size: 0.9rem;
-  font-weight: 700;
-  color: var(--text-primary);
-}
-
-.view-dropdown-subtitle {
-  font-size: 0.72rem;
-  color: var(--text-muted);
-  letter-spacing: 0.02em;
-}
-
-.view-dropdown-menu {
-  position: absolute;
-  top: calc(100% + 0.5rem);
-  right: 0;
-  width: 100%;
-  padding: 0.5rem;
-  border-radius: 14px;
-  display: flex;
-  flex-direction: column;
-  gap: 0.35rem;
-  z-index: 20;
-}
-
-.view-dropdown-option {
+.view-switch-btn {
   border: none;
   background: transparent;
-  color: var(--text-secondary);
-  display: flex;
-  flex-direction: column;
-  gap: 0.2rem;
-  padding: 0.6rem 0.75rem;
-  border-radius: 12px;
-  text-align: left;
+  color: var(--text-muted);
+  font-size: 0.8rem;
+  font-weight: 600;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
   cursor: pointer;
   transition: all 0.2s ease;
 }
 
-.view-dropdown-option .option-title {
-  font-size: 0.85rem;
-  font-weight: 600;
-}
-
-.view-dropdown-option .option-subtitle {
-  font-size: 0.7rem;
-  color: var(--text-muted);
-}
-
-.view-dropdown-option:hover {
+.view-switch-btn:hover {
+  color: var(--text-primary);
   background: rgba(92, 200, 255, 0.12);
-  color: var(--text-primary);
 }
 
-.view-dropdown-option.active {
+.view-switch-btn.active {
+  color: var(--text-primary);
   background: rgba(92, 200, 255, 0.2);
-  color: var(--text-primary);
   border: 1px solid rgba(92, 200, 255, 0.4);
-}
-
-.view-dropdown-trigger svg.rotate {
-  transform: rotate(180deg);
 }
 
 .action-buttons {
@@ -375,7 +315,7 @@
   }
 
   .header-title {
-    font-size: 1.25rem;
+    font-size: 1.2rem;
   }
 
   .view-utility-row {
@@ -383,12 +323,9 @@
     width: 100%;
   }
 
-  .view-dropdown {
+  .view-switch {
     width: 100%;
-  }
-
-  .view-dropdown-trigger {
-    width: 100%;
+    justify-content: space-between;
   }
 
   .action-buttons {
@@ -398,7 +335,7 @@
 
 @media (max-width: 480px) {
   .header {
-    padding: 0.75rem 0;
+    padding: 0.6rem 0;
   }
 
   .header-content {
@@ -409,8 +346,8 @@
     gap: 0.5rem;
   }
 
-  .today-btn {
-    padding: 0.375rem 0.75rem;
+  .today-cta {
+    padding: 0.3rem 0.75rem;
     font-size: 0.8rem;
   }
 

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { motion } from 'framer-motion';
-import { Calendar, Settings, ChevronLeft, ChevronRight, Send, Sparkles, ImagePlus, ChevronDown } from 'lucide-react';
+import { Calendar, Settings, ChevronLeft, ChevronRight, Send, Sparkles, ImagePlus } from 'lucide-react';
 import { useCalendar, CALENDAR_VIEWS } from '../../contexts/CalendarContext';
 import { formatDate, formatFullDate, formatViewLabel } from '../../utils/dateUtils';
 import { registerShortcut } from '../../utils/keyboardShortcuts';
@@ -10,10 +10,8 @@ import './Header.css';
 const Header = ({ onOpenSettings, onOpenAI }) => {
   const [quickInput, setQuickInput] = useState('');
   const [isProcessing, setIsProcessing] = useState(false);
-  const [isViewMenuOpen, setIsViewMenuOpen] = useState(false);
   const imageInputRef = useRef(null);
   const quickInputRef = useRef(null);
-  const viewMenuRef = useRef(null);
   const { currentDate, view, setView, navigateDate, goToToday, openEventModal } = useCalendar();
 
   const viewButtons = [
@@ -53,17 +51,6 @@ const Header = ({ onOpenSettings, onOpenAI }) => {
       unregisterT();
     };
   }, [openEventModal, goToToday]);
-
-  useEffect(() => {
-    if (!isViewMenuOpen) return;
-    const handleClickOutside = (event) => {
-      if (viewMenuRef.current && !viewMenuRef.current.contains(event.target)) {
-        setIsViewMenuOpen(false);
-      }
-    };
-    document.addEventListener('mousedown', handleClickOutside);
-    return () => document.removeEventListener('mousedown', handleClickOutside);
-  }, [isViewMenuOpen]);
 
   useEffect(() => {
     const handleKeyDown = (event) => {
@@ -122,7 +109,7 @@ const Header = ({ onOpenSettings, onOpenAI }) => {
     onOpenAI();
   };
 
-  const activeViewLabel = viewButtons.find((item) => item.key === view)?.label || 'View';
+  const activeViewLabel = viewButtons.find((item) => item.key === view)?.label || 'Day';
 
   return (
     <motion.header
@@ -162,17 +149,6 @@ const Header = ({ onOpenSettings, onOpenAI }) => {
                 <motion.button
                   whileHover={{ scale: 1.05 }}
                   whileTap={{ scale: 0.95 }}
-                  onClick={goToToday}
-                  className="btn icon-link today-btn"
-                  title="Jump to today"
-                  aria-label="Jump to today"
-                >
-                  <Calendar size={18} />
-                </motion.button>
-
-                <motion.button
-                  whileHover={{ scale: 1.05 }}
-                  whileTap={{ scale: 0.95 }}
                   onClick={() => navigateDate(1)}
                   className="btn nav-btn"
                   aria-label="Next date"
@@ -181,8 +157,21 @@ const Header = ({ onOpenSettings, onOpenAI }) => {
                 </motion.button>
               </div>
 
+              <motion.button
+                whileHover={{ scale: 1.03 }}
+                whileTap={{ scale: 0.97 }}
+                onClick={goToToday}
+                className="btn today-cta"
+                title="Jump to today"
+                aria-label="Jump to today"
+              >
+                <Calendar size={16} />
+                Today
+              </motion.button>
+
               <div className="header-title-group">
                 <h2 className="header-title">{getHeaderTitle()}</h2>
+                <p className="header-subtitle">{getViewLabel(activeViewLabel).replace(' View', '')}</p>
               </div>
             </div>
           </div>
@@ -190,42 +179,19 @@ const Header = ({ onOpenSettings, onOpenAI }) => {
           {/* View Controls and Actions */}
           <div className="header-right">
             <div className="view-utility-row">
-              <div className="view-dropdown" ref={viewMenuRef}>
-                <motion.button
-                  type="button"
-                  whileHover={{ scale: 1.02 }}
-                  whileTap={{ scale: 0.98 }}
-                  onClick={() => setIsViewMenuOpen((prev) => !prev)}
-                  className="view-dropdown-trigger glass"
-                  aria-haspopup="listbox"
-                  aria-expanded={isViewMenuOpen}
-                >
-                  <div className="view-dropdown-label">
-                    <span className="view-dropdown-title">{getViewLabel(activeViewLabel)}</span>
-                    <span className="view-dropdown-subtitle">Select view</span>
-                  </div>
-                  <ChevronDown size={16} className={isViewMenuOpen ? 'rotate' : ''} />
-                </motion.button>
-                {isViewMenuOpen && (
-                  <div className="view-dropdown-menu glass" role="listbox">
-                    {viewButtons.map(({ key, label }) => (
-                      <button
-                        key={key}
-                        type="button"
-                        role="option"
-                        aria-selected={view === key}
-                        className={`view-dropdown-option ${view === key ? 'active' : ''}`}
-                        onClick={() => {
-                          setView(key);
-                          setIsViewMenuOpen(false);
-                        }}
-                      >
-                        <span className="option-title">{label} View</span>
-                        <span className="option-subtitle">{getViewLabel(label)}</span>
-                      </button>
-                    ))}
-                  </div>
-                )}
+              <div className="view-switch" role="tablist" aria-label="Calendar view">
+                {viewButtons.map(({ key, label }) => (
+                  <button
+                    key={key}
+                    type="button"
+                    role="tab"
+                    aria-selected={view === key}
+                    className={`view-switch-btn ${view === key ? 'active' : ''}`}
+                    onClick={() => setView(key)}
+                  >
+                    {label}
+                  </button>
+                ))}
               </div>
 
               <form onSubmit={handleAICommand} className="quick-event-form inline">

--- a/src/components/Settings/Settings.css
+++ b/src/components/Settings/Settings.css
@@ -13,8 +13,8 @@
 
 .settings-modal.pro-theme {
   width: 100%;
-  max-width: 900px;
-  height: min(100vh, 720px);
+  max-width: 960px;
+  height: min(100vh, 680px);
   max-height: 100vh;
   background: rgba(15, 23, 42, 0.8);
   -webkit-backdrop-filter: blur(24px);
@@ -45,7 +45,7 @@
 
 /* Sidebar */
 .settings-sidebar {
-  width: 240px;
+  width: 230px;
   background: rgba(0, 0, 0, 0.2);
   border-right: 1px solid rgba(255, 255, 255, 0.05);
   display: flex;
@@ -156,7 +156,7 @@
 }
 
 .main-header {
-  padding: 32px 40px 24px;
+  padding: 24px 32px 18px;
   display: flex;
   justify-content: space-between;
   align-items: flex-start;
@@ -199,7 +199,7 @@
 .tab-content-wrapper {
   flex: 1;
   overflow: hidden;
-  padding: 0 40px 40px;
+  padding: 0 32px 28px;
 }
 
 .theme-card {
@@ -245,8 +245,8 @@
 
 .ai-settings-grid {
   display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
-  gap: 16px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 14px;
   align-items: start;
 }
 
@@ -254,10 +254,10 @@
   background: rgba(15, 23, 42, 0.6);
   border: 1px solid rgba(255, 255, 255, 0.08);
   border-radius: 18px;
-  padding: 18px;
+  padding: 14px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .ai-card-wide {
@@ -267,7 +267,7 @@
 .ai-card-header {
   display: flex;
   align-items: flex-start;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: wrap;
 }
 
@@ -278,6 +278,7 @@
 .ai-card-header p {
   margin: 0;
   color: #cbd5f5;
+  text-wrap: balance;
 }
 
 .ai-accordion {
@@ -293,7 +294,7 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
-  padding: 16px;
+  padding: 12px 14px;
   gap: 12px;
   flex-wrap: wrap;
 }
@@ -324,10 +325,10 @@
 }
 
 .ai-accordion-body {
-  padding: 0 16px 18px;
+  padding: 0 14px 14px;
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 12px;
 }
 
 .ai-inline-note {
@@ -341,7 +342,8 @@
 
 .ai-inline-note p {
   margin: 0;
-  flex: 1 1 260px;
+  flex: 1 1 240px;
+  text-wrap: balance;
 }
 
 .ai-inline-status {
@@ -353,7 +355,7 @@
 
 .ai-guidance {
   display: grid;
-  gap: 12px;
+  gap: 10px;
 }
 
 .ai-guidance-item {
@@ -361,6 +363,7 @@
   flex-direction: column;
   gap: 4px;
   color: #cbd5f5;
+  text-wrap: balance;
 }
 
 .ai-guidance-title {
@@ -369,23 +372,58 @@
 }
 
 .storage-actions {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
   gap: 12px;
 }
 
-.mui-storage-button {
-  border-color: var(--border-color) !important;
-  color: var(--text-color) !important;
-  text-transform: none !important;
-  font-weight: 600 !important;
-  padding: 10px 16px !important;
-  border-radius: 12px !important;
+.storage-actions-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
 }
 
-.mui-storage-button:hover {
-  border-color: var(--accent-color) !important;
-  background: rgba(99, 102, 241, 0.12) !important;
+.storage-action-button {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid var(--border-color);
+  background: rgba(15, 23, 42, 0.35);
+  color: var(--text-color);
+  text-align: left;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.storage-action-button small {
+  display: block;
+  margin-top: 4px;
+  color: var(--muted-text);
+  font-size: 0.75rem;
+}
+
+.storage-action-button:hover {
+  border-color: var(--accent-color);
+  background: rgba(99, 102, 241, 0.12);
+  transform: translateY(-1px);
+}
+
+.storage-action-button.warning {
+  border-color: rgba(234, 179, 8, 0.4);
+}
+
+.storage-action-button.warning:hover {
+  background: rgba(234, 179, 8, 0.12);
+}
+
+.storage-action-button.danger {
+  border-color: rgba(244, 63, 94, 0.4);
+}
+
+.storage-action-button.danger:hover {
+  background: rgba(244, 63, 94, 0.12);
 }
 
 .about-details {
@@ -411,7 +449,7 @@
 .content-section {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
 }
 
 /* Pro Card */
@@ -419,7 +457,7 @@
   background: rgba(255, 255, 255, 0.03);
   border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 20px;
-  padding: 24px;
+  padding: 20px;
 }
 
 .pro-user-info {
@@ -689,14 +727,14 @@
 }
 
 .local-brain-test {
-  margin-top: 16px;
-  padding: 14px;
+  margin-top: 12px;
+  padding: 12px;
   border-radius: 14px;
   background: rgba(15, 23, 42, 0.25);
   border: 1px solid rgba(148, 163, 184, 0.16);
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 10px;
 }
 
 .local-brain-test-header {
@@ -782,7 +820,7 @@
   display: flex;
   flex-direction: column;
   gap: 10px;
-  max-height: 220px;
+  max-height: 160px;
   overflow: auto;
   padding-right: 4px;
 }
@@ -828,7 +866,7 @@
   justify-content: space-between;
   align-items: center;
   gap: 16px;
-  margin-bottom: 16px;
+  margin-bottom: 8px;
 }
 
 .storage-meta {
@@ -930,12 +968,6 @@
 }
 
 /* Grid & Action Cards */
-.grid-2 {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 20px;
-}
-
 .pro-action-card {
   background: rgba(255, 255, 255, 0.02);
   border: 1px solid rgba(255, 255, 255, 0.05);
@@ -1176,4 +1208,15 @@
   margin: 4px 0 0;
   font-size: 0.75rem;
   color: #94a3b8;
+}
+
+@media (max-width: 960px) {
+  .ai-settings-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .storage-actions,
+  .storage-actions-grid {
+    grid-template-columns: 1fr;
+  }
 }

--- a/src/components/Settings/Settings.jsx
+++ b/src/components/Settings/Settings.jsx
@@ -1,7 +1,6 @@
 import { useState, useEffect, useRef } from 'react';
 import { motion, AnimatePresence } from 'framer-motion';
 import { X, Key, Save, Eye, EyeOff, ExternalLink, Download, Calendar as CalendarIcon, RefreshCw, CheckCircle, LogOut, User, Sparkles, MessageSquare, Clock } from 'lucide-react';
-import Button from '@mui/material/Button';
 import { CloudDownloadOutlined, DeleteOutline, DeleteSweepOutlined, EventNoteOutlined } from '@mui/icons-material';
 import { geminiService } from '../../services/geminiService';
 import { localBrainService } from '../../services/localBrainService';
@@ -469,7 +468,7 @@ const Settings = ({ isOpen, onClose }) => {
                       <div className="pro-card theme-card">
                         <div>
                           <h4>Theme Preference</h4>
-                          <p>Switch between light and dark mode with CSS variable theming.</p>
+                          <p>Toggle light or dark mode across the workspace.</p>
                         </div>
                         <button
                           type="button"
@@ -491,8 +490,8 @@ const Settings = ({ isOpen, onClose }) => {
                           <div className="ai-card-header">
                             <Sparkles size={20} className="sparkle-icon" />
                             <div>
-                              <h4>Gemini 3.0 Pro</h4>
-                              <p>Your calendar uses frontier models for intelligent parsing, assistant replies, and scheduling logic.</p>
+                              <h4>Gemini Pro</h4>
+                              <p>Connect Gemini to power scheduling, smart parsing, and assistant replies.</p>
                             </div>
                           </div>
 
@@ -547,13 +546,13 @@ const Settings = ({ isOpen, onClose }) => {
                         </section>
 
                         <section className="ai-card">
-                          <details className="ai-accordion" open>
+                          <details className="ai-accordion">
                             <summary>
                               <div className="ai-accordion-title">
                                 <Sparkles size={18} />
                                 <div>
                                   <h4>Offline Backup Brain (Beta)</h4>
-                                  <p>Run a compact model locally for offline sessions or cost control.</p>
+                                  <p>Run a compact model locally for offline coverage and cost control.</p>
                                 </div>
                               </div>
                               <span className="ai-accordion-meta">Local model controls</span>
@@ -562,7 +561,7 @@ const Settings = ({ isOpen, onClose }) => {
                               {!isLocalBrainLoaded && !localBrainProgress && (
                                 <div className="ai-inline-note">
                                   <p>
-                                    Requires ~1.5GB download (first time only). Uses your device GPU and stays on-device.
+                                    Requires ~1.5GB download the first time. Uses your device GPU and stays on-device.
                                   </p>
                                   <button onClick={handleInitLocalBrain} className="pro-btn-secondary">
                                     <Download size={14} /> Initialize Backup Brain
@@ -587,7 +586,7 @@ const Settings = ({ isOpen, onClose }) => {
                                       Unload
                                     </button>
                                   </div>
-                                  <p className="local-brain-note">Offline Brain is ready. Toggle the switch below to prefer local inference.</p>
+                                  <p className="local-brain-note">Offline Brain is ready. Toggle below to route chats locally.</p>
                                 </>
                               )}
 
@@ -610,7 +609,7 @@ const Settings = ({ isOpen, onClose }) => {
                                 <div className="local-brain-test-header">
                                   <div>
                                     <h5>Local Model Test Chat</h5>
-                                    <p>Send a custom message and confirm live generation.</p>
+                                    <p>Send a message and confirm live generation.</p>
                                   </div>
                                   <button
                                     onClick={handleLocalBrainTest}
@@ -684,21 +683,21 @@ const Settings = ({ isOpen, onClose }) => {
                             <Sparkles size={18} />
                             <div>
                               <h4>Engine Guidance</h4>
-                              <p>CalAI uses your connected services to improve scheduling and protect your data.</p>
+                              <p>CalAI uses your connected services to improve scheduling and data safety.</p>
                             </div>
                           </div>
                           <div className="ai-guidance">
                             <div className="ai-guidance-item">
                               <span className="ai-guidance-title">Privacy-first flows</span>
-                              <p>Keys are stored securely and never displayed once saved. Local Brain runs entirely on-device.</p>
+                              <p>Keys are stored securely and never displayed once saved. Local Brain stays on-device.</p>
                             </div>
                             <div className="ai-guidance-item">
                               <span className="ai-guidance-title">Smart parsing</span>
-                              <p>Natural language commands translate into structured events with timezone-aware defaults.</p>
+                              <p>Natural language commands become structured events with timezone-aware defaults.</p>
                             </div>
                             <div className="ai-guidance-item">
                               <span className="ai-guidance-title">Cost controls</span>
-                              <p>Switch to the Offline Brain to save API credits while preserving the assistant experience.</p>
+                              <p>Use the Offline Brain to save API credits while preserving the assistant flow.</p>
                             </div>
                           </div>
                         </section>
@@ -734,7 +733,7 @@ const Settings = ({ isOpen, onClose }) => {
                       <div className="storage-summary glass-card">
                         <div>
                           <h4>Local Event Storage</h4>
-                          <p>Manage your on-device calendar cache.</p>
+                          <p>Review and manage the on-device calendar cache.</p>
                         </div>
                         <div className="storage-meta">
                           <div>
@@ -750,43 +749,37 @@ const Settings = ({ isOpen, onClose }) => {
                         </div>
                       </div>
 
-                      <div className="grid-2">
-                        <Button
-                          variant="outlined"
-                          onClick={handleExportData}
-                          startIcon={<CloudDownloadOutlined />}
-                          className="mui-storage-button"
-                        >
-                          Export JSON
-                        </Button>
-                        <Button
-                          variant="outlined"
-                          onClick={handleExportICS}
-                          startIcon={<EventNoteOutlined />}
-                          className="mui-storage-button"
-                        >
-                          Export ICS
-                        </Button>
+                      <div className="storage-actions-grid">
+                        <button type="button" onClick={handleExportData} className="storage-action-button">
+                          <CloudDownloadOutlined fontSize="small" />
+                          <div>
+                            <span>Export JSON</span>
+                            <small>Download a full calendar backup.</small>
+                          </div>
+                        </button>
+                        <button type="button" onClick={handleExportICS} className="storage-action-button">
+                          <EventNoteOutlined fontSize="small" />
+                          <div>
+                            <span>Export ICS</span>
+                            <small>Share events with other calendars.</small>
+                          </div>
+                        </button>
                       </div>
                       <div className="storage-actions">
-                        <Button
-                          variant="outlined"
-                          color="warning"
-                          onClick={handleDeleteByName}
-                          startIcon={<DeleteSweepOutlined />}
-                          className="mui-storage-button"
-                        >
-                          Delete Events by Name
-                        </Button>
-                        <Button
-                          variant="outlined"
-                          color="error"
-                          onClick={handleClearAllData}
-                          startIcon={<DeleteOutline />}
-                          className="mui-storage-button"
-                        >
-                          Clear Local Events
-                        </Button>
+                        <button type="button" onClick={handleDeleteByName} className="storage-action-button warning">
+                          <DeleteSweepOutlined fontSize="small" />
+                          <div>
+                            <span>Delete by Name</span>
+                            <small>Remove repeated events by exact title.</small>
+                          </div>
+                        </button>
+                        <button type="button" onClick={handleClearAllData} className="storage-action-button danger">
+                          <DeleteOutline fontSize="small" />
+                          <div>
+                            <span>Clear Local Events</span>
+                            <small>Reset cached data on this device.</small>
+                          </div>
+                        </button>
                       </div>
 
                       <div className="info-box" style={{ marginTop: '16px', background: 'rgba(56, 189, 248, 0.08)', border: '1px solid rgba(56, 189, 248, 0.2)' }}>
@@ -829,15 +822,15 @@ const Settings = ({ isOpen, onClose }) => {
                       <div className="about-details">
                         <h4>Professional AI Calendar</h4>
                         <p>
-                          CalAI is an intelligent scheduling workspace that pairs real-time calendaring with AI-powered
-                          orchestration. From natural language entries to resilient syncing, it keeps every commitment
-                          aligned with your day.
+                          CalAI is a dedicated AI calendar designed for teams and professionals who need fast, reliable
+                          scheduling. It blends real-time calendaring with AI-driven parsing so every commitment stays
+                          aligned and searchable.
                         </p>
                         <ul>
-                          <li>AI-first scheduling with verified event parsing and timezone awareness.</li>
-                          <li>Offline Backup Brain to keep planning available even without connectivity.</li>
+                          <li>AI-first scheduling with verified parsing and timezone awareness.</li>
+                          <li>Offline Backup Brain to keep planning available without connectivity.</li>
                           <li>Secure storage for API credentials with masked UI protection.</li>
-                          <li>Integrated Google Calendar sync and export-ready formats.</li>
+                          <li>Integrated Google Calendar sync plus export-ready formats.</li>
                         </ul>
                       </div>
                       <div className="legal-links-alt">

--- a/src/pages/Contact.tsx
+++ b/src/pages/Contact.tsx
@@ -1,0 +1,32 @@
+import PolicyLayout from './PolicyLayout';
+
+const Contact = () => (
+  <PolicyLayout
+    title="Contact"
+    subtitle="Reach CalAI for support, privacy requests, or business inquiries."
+  >
+    <h2>Support</h2>
+    <p>
+      Email <strong>support@calai.app</strong> for product questions, billing, or technical help. We aim to respond
+      within two business days.
+    </p>
+
+    <h2>Privacy & GDPR Requests</h2>
+    <p>
+      For data access, deletion, or portability requests, email <strong>privacy@calai.app</strong>. Please include
+      the email associated with your account for verification.
+    </p>
+
+    <h2>Business & Partnerships</h2>
+    <p>
+      Reach out to <strong>partners@calai.app</strong> for integrations, calendar partnerships, or enterprise plans.
+    </p>
+
+    <h2>Office Hours</h2>
+    <p>
+      Monday–Friday, 9:00 AM–6:00 PM Pacific Time. We monitor urgent issues outside these hours when possible.
+    </p>
+  </PolicyLayout>
+);
+
+export default Contact;

--- a/src/pages/Privacy.tsx
+++ b/src/pages/Privacy.tsx
@@ -1,0 +1,59 @@
+import PolicyLayout from './PolicyLayout';
+
+const Privacy = () => (
+  <PolicyLayout
+    title="Privacy Policy"
+    subtitle="How CalAI collects, uses, and protects data for AI-powered scheduling."
+  >
+    <h2>1. Information We Collect</h2>
+    <p>
+      CalAI collects account identifiers (such as email and display name), calendar metadata, and settings required
+      to deliver scheduling features. Event details you create are stored with your account and shared only with
+      services you explicitly connect.
+    </p>
+
+    <h2>2. How We Use Data</h2>
+    <p>
+      We use your data to deliver calendar functionality, improve AI scheduling accuracy, provide support, and keep
+      the service secure. We do not sell personal information to third parties.
+    </p>
+
+    <h2>3. Legal Bases for Processing</h2>
+    <p>
+      We process data under contractual necessity (providing the service), legitimate interest (service improvement),
+      and consent (optional integrations and marketing). You may withdraw consent at any time.
+    </p>
+
+    <h2>4. Cookies & Advertising</h2>
+    <p>
+      We use cookies for authentication, preferences, and analytics. Google AdSense may use cookies or device
+      identifiers to personalize ads. You can manage ad personalization in Google Ads Settings or your browser.
+    </p>
+
+    <h2>5. Data Retention</h2>
+    <p>
+      We retain data while your account is active or as needed to provide services. You can request deletion, and we
+      will remove or anonymize data within a reasonable timeframe unless legal obligations apply.
+    </p>
+
+    <h2>6. Your Rights</h2>
+    <ul>
+      <li>Access, correct, export, or delete your data.</li>
+      <li>Restrict or object to processing in certain circumstances.</li>
+      <li>Receive data portability where applicable.</li>
+    </ul>
+
+    <h2>7. Security</h2>
+    <p>
+      We use encryption in transit, secure storage for credentials, and access controls. API keys are masked in the
+      UI and stored securely to reduce exposure risk.
+    </p>
+
+    <h2>8. Contact</h2>
+    <p>
+      For privacy requests, contact <strong>privacy@calai.app</strong> or visit our Contact page.
+    </p>
+  </PolicyLayout>
+);
+
+export default Privacy;

--- a/src/pages/Terms.tsx
+++ b/src/pages/Terms.tsx
@@ -1,0 +1,52 @@
+import PolicyLayout from './PolicyLayout';
+
+const Terms = () => (
+  <PolicyLayout
+    title="Terms of Service"
+    subtitle="Rules for using CalAI, including acceptable use and account responsibilities."
+  >
+    <h2>1. Account Responsibilities</h2>
+    <p>
+      You are responsible for maintaining the confidentiality of your credentials and for all activity under your
+      account. Notify us promptly if you suspect unauthorized access.
+    </p>
+
+    <h2>2. Acceptable Use</h2>
+    <p>
+      You agree not to misuse the service, attempt to disrupt infrastructure, or upload unlawful content. We may
+      suspend accounts that violate these standards.
+    </p>
+
+    <h2>3. AI Features</h2>
+    <p>
+      AI-generated suggestions are provided as scheduling assistance. You remain responsible for confirming event
+      details, attendees, and commitments created through the assistant.
+    </p>
+
+    <h2>4. Integrations</h2>
+    <p>
+      When you connect third-party services (such as Google Calendar), you authorize CalAI to access the minimum
+      scopes required to sync schedules. You can revoke access at any time through the provider or your settings.
+    </p>
+
+    <h2>5. Intellectual Property</h2>
+    <p>
+      CalAI and its branding are protected by applicable intellectual property laws. You may not copy, distribute,
+      or reverse engineer any part of the service without permission.
+    </p>
+
+    <h2>6. Disclaimers</h2>
+    <p>
+      CalAI is provided on an “as is” and “as available” basis. We do not guarantee uninterrupted availability and
+      are not liable for indirect or consequential damages, to the extent permitted by law.
+    </p>
+
+    <h2>7. Termination</h2>
+    <p>
+      You may stop using CalAI at any time. We may terminate or suspend accounts for violations of these terms or to
+      protect platform integrity.
+    </p>
+  </PolicyLayout>
+);
+
+export default Terms;


### PR DESCRIPTION
### Motivation
- Make the header more compact and clearer by exposing only Day/Week/Month/Year, separating the Today action, and centering navigation controls for a tighter UX.
- Improve the Settings modal's layout and copy so AI engine and storage controls fit without scrolling and appear more professional.
- Prepare the site for AdSense/legal compliance by adding Privacy, Terms and Contact pages that use the existing policy layout.

### Description
- Header: replaced the dropdown view menu with inline view buttons for `Day`, `Week`, `Month`, `Year`, added a separate `Today` CTA, displayed the view label as a subtitle, and reduced header padding and spacing to shrink height (`src/components/Header/Header.jsx`, `src/components/Header/Header.css`).
- Settings: tightened modal dimensions and spacing, improved AI engine copy and formatting (accordion tweaks, reduced two-word wrapping by adjusting paddings), added a clearer theme toggle label and preserved CSS variable theming, and rebuilt storage controls with professional action cards/buttons instead of oversized defaults (`src/components/Settings/Settings.jsx`, `src/components/Settings/Settings.css`).
- About content: updated the About copy to emphasize a professional AI calendar product rather than a generic todo concept (`src/components/Settings/Settings.jsx`).
- AdSense / policy pages: added new policy/contact pages `src/pages/Privacy.tsx`, `src/pages/Terms.tsx`, and `src/pages/Contact.tsx` wired to the existing `PolicyLayout` to provide compliant baseline text and ad slots (`src/pages/PolicyLayout.jsx`, new files added).
- Minor cleanups: removed unused dropdown state/refs and unused layout imports in header, adjusted responsive CSS rules for tighter mobile behavior.

### Testing
- Started the dev server with `npm run dev -- --host 0.0.0.0 --port 4173`, which successfully served the app (Local/Network URLs printed), but Vite reported unresolved-import warnings for some optional dependencies (`react-router-dom`, `@mui/icons-material`, `react-google-adsense`) during dependency scan.
- Ran a Playwright smoke script to load `/privacy` and capture a screenshot (`artifacts/privacy-page.png`), which completed successfully and produced the page snapshot.
- No automated unit tests were added or run beyond the above dev/server and Playwright smoke check.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6976cce8543c832eb6b3558193751b18)